### PR TITLE
.deb package 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 os: linux
 sudo: false
 dist: trusty
+#dist: xenial  ### wait ubuntu 16.04's coming from travis-ci
 stages:
   - Build & Test
   - Packaging
@@ -141,24 +142,35 @@ jobs:
 
 
 ############## Packaging Deb ##############
-    #- stage: Packaging
-      #cache:
-        #- directories:
-          #- *build_dst_path
-          #### > Save the deb directory to reuse in other jobs
-          #- &deb_dst_path build-deb
-      #before_install:
-        ###### Clean cache folder
-        #- rm -rf $DEB_DST_PATH/*
+    # - stage: Packaging
+    #   cache:
+    #     - directories:
+    #       - *build_dst_path
+    #       ### > Save the deb directory to reuse in other jobs
+    #       - &deb_dst_path build-deb
+    #   addons:
+    #     apt:
+    #       sources:
+    #          - ubuntu-toolchain-r-test
+    #       packages:
+    #          - debhelper
+    #          - fakeroot
+    #          - qt5-qmake 
+    #          - qt5-default
+    #          - qttools5-dev-tools
+    #   before_install:
+    #     ##### Clean cache folder
+    #     - rm -rf $DEB_DST_PATH/*
 
-      #script:
-        #- ls -alhR $BUILD_DST_PATH
-        #- echo "Do .deb" > $DEB_DST_PATH/dev.txt
-        #- ls -alhR $DEB_DST_PATH
+    #   script:
+    #     - ls -alhR $BUILD_DST_PATH
+    #     - echo "Do .deb" > $DEB_DST_PATH/dev.txt
+    #     - ls -alhR $DEB_DST_PATH
+    #     - dpkg-buildpackage -rfakeroot -b -us -uc
 
-      #after_script:
-        ##### Wait for the cache to update
-        #- sleep 10
+    #   after_script:
+    #     #### Wait for the cache to update
+    #     - sleep 10
 
 
 ############## Deploy ##############


### PR DESCRIPTION
Because the current travis environment is Ubuntu 14.04, it supports Qt version 5.2 (`qt5-qmake`  `qt5-default`  `qttools5-dev-tools` , more details, look at this https://pkgs.org/download/qt-default ) does not meet the minimum compile requirements, if compiled, there will be two errors about "New Signal Slot Syntax". But the good news is that travis is working on Ubuntu 16.04. What we have to do for the deb package is to wait for travis to release the 16.04 image.
I made changes can be used in the 16.04 environment, but now commented out.

P.S.  I want to achieve “pin capture to desktop/paste images as topmost floating windows” and already have ideas on how to achieve it. I will take the time to complete this work.