### PR TITLE
Fixed errors in desktop files

### DIFF
--- a/docs/desktopEntry/package/flameshot-config.desktop
+++ b/docs/desktopEntry/package/flameshot-config.desktop
@@ -1,6 +1,4 @@
-#!/usr/bin/env xdg-open
 [Desktop Entry]
-Encoding=UTF-8
 Name=Configure Flameshot
 Name[es]=Configurar Flameshot
 GenericName=Screenshot tool

--- a/docs/desktopEntry/package/flameshot-init.desktop
+++ b/docs/desktopEntry/package/flameshot-init.desktop
@@ -1,6 +1,4 @@
-#!/usr/bin/env xdg-open
 [Desktop Entry]
-Encoding=UTF-8
 Name=Launch Flameshot
 Name[es]=Iniciar Flameshot
 GenericName=Screenshot tool

--- a/docs/desktopEntry/package/flameshot.desktop
+++ b/docs/desktopEntry/package/flameshot.desktop
@@ -1,8 +1,7 @@
-#!/usr/bin/env xdg-open
 [Desktop Entry]
-Encoding=UTF-8
 Name=Take graphical screenshot
 Name[es]=Tomar captura gráfica
+GenericName=Screen capture tool
 GenericName[es]=Herramienta de captura de pantalla
 Comment=Powerfull yet simple to use screenshot software.
 Comment[es]=Potente pero simple de usar software de capturas.


### PR DESCRIPTION
Fixed warnings and errors in desktop files:
 * removed shebang;
 * removed encoding tag as it no longer required;
 * added missing GenericName;
 * changed chmod from 0755 to 0644.