### PR TITLE
appdata: Install appdata into /usr/share/metainfo

### DIFF
--- a/flameshot.pro
+++ b/flameshot.pro
@@ -221,7 +221,7 @@ unix:!macx {
     completion.path = $${BASEDIR}$${PREFIX}/share/bash-completion/completions/
     completion.files = docs/bash-completion/flameshot
     
-    appdata.path = $${BASEDIR}$${PREFIX}/share/appdata/
+    appdata.path = $${BASEDIR}$${PREFIX}/share/metainfo/
     appdata.files = docs/appdata/flameshot.appdata.xml
 
     desktopentry.path = $${BASEDIR}$${PREFIX}/share/applications


### PR DESCRIPTION
While examining the source code, I found that the appdata description
file was installed into the legacy path /usr/share/appdata/ .

This commit would install appdata info into the canonical dir
/usr/share/metainfo/ .

Refs:
 https://lintian.debian.org/tags/appstream-metadata-in-legacy-location.html