### PR TITLE
Fix whitespace handling

### DIFF
--- a/src/capture/workers/launcher/applauncherwidget.cpp
+++ b/src/capture/workers/launcher/applauncherwidget.cpp
@@ -101,7 +101,7 @@ void AppLauncherWidget::launch(const QModelIndex &index) {
 		}
 	}
 	QString command = index.data(Qt::UserRole).toString().replace(
-				QRegExp("(\%.)"), m_tempFile);
+				QRegExp("(\%.)"), '"' + m_tempFile + '"');
 	bool inTerminal = index.data(Qt::UserRole+1).toBool() ||
 			m_terminalCheckbox->isChecked();
 	if (inTerminal) {


### PR DESCRIPTION
Fixes errors external apps give when you have whitespaces in the file name and you try to open the file in an external editor (e.g. GIMP). This happens because whitespaces are interpreted as shell argument separators.

Screenshot:
![GIMP errors](https://user-images.githubusercontent.com/2781117/34916479-746d4a58-f952-11e7-8a75-969523b239c4.png)