### PR TITLE
Fixed qmfile.path, added prefix

### DIFF
--- a/flameshot.pro
+++ b/flameshot.pro
@@ -209,7 +209,7 @@ unix:!macx {
 
     target.path = $${BASEDIR}$${PREFIX}/bin/
 
-    qmfile.path = $${BASEDIR}/usr/share/flameshot/translations/
+    qmfile.path = $${BASEDIR}$${PREFIX}/share/flameshot/translations/
     qmfile.files = $${TRANSLATIONS_FILES}
 
     dbus.path = $${BASEDIR}$${PREFIX}/share/dbus-1/interfaces/


### PR DESCRIPTION
It is necessary when using a packaging system like flatpak.