### PR TITLE
README.md: Update info about flameshot in distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,11 @@ Steps for using the configuration:
 
 ## Installation
 
-There are a packages available for a few distros:
-- [Arch](https://aur.archlinux.org/packages/flameshot/)
+There are packages available for a few distros:
+- [Arch](https://www.archlinux.org/packages/community/x86_64/flameshot/)
+  + Snapshot also available via AUR: [flameshot-git](https://aur.archlinux.org/packages/flameshot-git).
+- [Debian 10+](https://tracker.debian.org/pkg/flameshot): `apt install flameshot`
+- [Ubuntu 18.04+](https://launchpad.net/ubuntu/+source/flameshot): `apt install flameshot`
 - [openSUSE](https://software.opensuse.org/package/flameshot)
 - [Void Linux](https://github.com/voidlinux/void-packages/tree/master/srcpkgs/flameshot) (`xbps-install flameshot`)
 - [Docker](https://github.com/ManuelLR/docker-flameshot)


### PR DESCRIPTION
Recent joint work with several Linux distributions needs to be reflected in the "Installation" section of README.md.

* @farseerfc took over the maintenance of flameshot package in Arch Linux as TU. The package is now in [community].
* I am maintaining flameshot in Debian. This means that flameshot will be available in Debian 10+, Ubuntu 18.04+ and all following Linux derivatives based on Debian.