### PR TITLE
README - point out flameshot must be running.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 If you want to contribute check the [CONTRIBUTING.md](./CONTRIBUTING.md)
 
 ## Usage
-Example commands:
+Example commands (all assuming flameshot is already running in the background):
 - capture with GUI:
 
    `flameshot gui`


### PR DESCRIPTION
Motivation: At least twice I have forgotten about this and become
confused by the fact that commands like `flameshot gui` will just exit
without doing anything.

Ideally an error should be printed to indicate that flameshot isn't
running, but this README tweak should make it more likely to be
realized by someone double checking usage instructions.