### PR TITLE
Pop notifications after captures are saved in clipboard

### DIFF
--- a/src/capture/workers/screenshotsaver.cpp
+++ b/src/capture/workers/screenshotsaver.cpp
@@ -31,6 +31,9 @@ ScreenshotSaver::ScreenshotSaver()
 
 void ScreenshotSaver::saveToClipboard(const QPixmap &capture) {
     QApplication::clipboard()->setPixmap(capture);
+    QString saveMessage;
+    saveMessage = QObject::tr("Capture saved to clipboard");
+    SystemNotification().sendMessage(saveMessage);
 }
 
 void ScreenshotSaver::saveToFilesystem(const QPixmap &capture,

--- a/translations/Internationalization_ca.ts
+++ b/translations/Internationalization_ca.ts
@@ -464,6 +464,10 @@ Utilitzeu la roda del ratolí per a canviar el gruix de l&apos;eina.</translatio
         <source>Unable to write in</source>
         <translation type="unfinished">No es pot escriure a</translation>
     </message>
+    <message>
+        <source>Capture saved to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RectangleTool</name>

--- a/translations/Internationalization_es.ts
+++ b/translations/Internationalization_es.ts
@@ -537,19 +537,24 @@ Usa la rueda del ratón para cambiar el grosor de la herramienta.</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/capture/workers/screenshotsaver.cpp" line="73"/>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="76"/>
         <source>Save Error</source>
         <translation>Error al Guardar</translation>
     </message>
     <message>
-        <location filename="../src/capture/workers/screenshotsaver.cpp" line="45"/>
-        <location filename="../src/capture/workers/screenshotsaver.cpp" line="67"/>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="48"/>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="70"/>
         <source>Capture saved as </source>
         <translation>Captura guardada como </translation>
     </message>
     <message>
-        <location filename="../src/capture/workers/screenshotsaver.cpp" line="47"/>
-        <location filename="../src/capture/workers/screenshotsaver.cpp" line="70"/>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="35"/>
+        <source>Capture saved to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="50"/>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="73"/>
         <source>Error trying to save as </source>
         <translation>Error intentando guardar como </translation>
     </message>

--- a/translations/Internationalization_fr.ts
+++ b/translations/Internationalization_fr.ts
@@ -537,19 +537,24 @@ Utiliser la molette pour changer l&apos;épaisseur de l&apos;outil.</translation
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/capture/workers/screenshotsaver.cpp" line="73"/>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="76"/>
         <source>Save Error</source>
         <translation>Erreur lors de la sauvegarde</translation>
     </message>
     <message>
-        <location filename="../src/capture/workers/screenshotsaver.cpp" line="45"/>
-        <location filename="../src/capture/workers/screenshotsaver.cpp" line="67"/>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="48"/>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="70"/>
         <source>Capture saved as </source>
         <translation>Capture d&apos;écran sauvegardée sous </translation>
     </message>
     <message>
-        <location filename="../src/capture/workers/screenshotsaver.cpp" line="47"/>
-        <location filename="../src/capture/workers/screenshotsaver.cpp" line="70"/>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="35"/>
+        <source>Capture saved to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="50"/>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="73"/>
         <source>Error trying to save as </source>
         <translation>Erreur lors de la sauvegarde sous </translation>
     </message>

--- a/translations/Internationalization_ka.ts
+++ b/translations/Internationalization_ka.ts
@@ -537,19 +537,24 @@ Use the Mouse Wheel to change the thickness of your tool.</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/capture/workers/screenshotsaver.cpp" line="73"/>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="76"/>
         <source>Save Error</source>
         <translation>შეცდომა შენახვისას</translation>
     </message>
     <message>
-        <location filename="../src/capture/workers/screenshotsaver.cpp" line="45"/>
-        <location filename="../src/capture/workers/screenshotsaver.cpp" line="67"/>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="48"/>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="70"/>
         <source>Capture saved as </source>
         <translation>სურათი შენახულია როგორც: </translation>
     </message>
     <message>
-        <location filename="../src/capture/workers/screenshotsaver.cpp" line="47"/>
-        <location filename="../src/capture/workers/screenshotsaver.cpp" line="70"/>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="35"/>
+        <source>Capture saved to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="50"/>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="73"/>
         <source>Error trying to save as </source>
         <translation>შეცდომა მცდელობისას შენახულიყო როგორც: </translation>
     </message>

--- a/translations/Internationalization_pl.ts
+++ b/translations/Internationalization_pl.ts
@@ -537,19 +537,24 @@ Użyj kółka myszy, aby zmienić grubość narzędzia do rysowania.</translatio
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/capture/workers/screenshotsaver.cpp" line="73"/>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="76"/>
         <source>Save Error</source>
         <translation>Błąd zapisu</translation>
     </message>
     <message>
-        <location filename="../src/capture/workers/screenshotsaver.cpp" line="45"/>
-        <location filename="../src/capture/workers/screenshotsaver.cpp" line="67"/>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="48"/>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="70"/>
         <source>Capture saved as </source>
         <translation>Zaznaczenie zapisano jako </translation>
     </message>
     <message>
-        <location filename="../src/capture/workers/screenshotsaver.cpp" line="47"/>
-        <location filename="../src/capture/workers/screenshotsaver.cpp" line="70"/>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="35"/>
+        <source>Capture saved to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="50"/>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="73"/>
         <source>Error trying to save as </source>
         <translation>Błąd przy próbie zapisu jako </translation>
     </message>

--- a/translations/Internationalization_ru.ts
+++ b/translations/Internationalization_ru.ts
@@ -537,19 +537,24 @@ Use the Mouse Wheel to change the thickness of your tool.</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/capture/workers/screenshotsaver.cpp" line="73"/>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="76"/>
         <source>Save Error</source>
         <translation>Ошибка сохранения</translation>
     </message>
     <message>
-        <location filename="../src/capture/workers/screenshotsaver.cpp" line="45"/>
-        <location filename="../src/capture/workers/screenshotsaver.cpp" line="67"/>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="48"/>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="70"/>
         <source>Capture saved as </source>
         <translation>Сохранить снимок как </translation>
     </message>
     <message>
-        <location filename="../src/capture/workers/screenshotsaver.cpp" line="47"/>
-        <location filename="../src/capture/workers/screenshotsaver.cpp" line="70"/>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="35"/>
+        <source>Capture saved to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="50"/>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="73"/>
         <source>Error trying to save as </source>
         <translation>Ошибка при попытке сохранить как </translation>
     </message>

--- a/translations/Internationalization_tr.ts
+++ b/translations/Internationalization_tr.ts
@@ -537,19 +537,24 @@ Araç boyutunu değiştirmek için Fare tekerleğini kullanın.</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/capture/workers/screenshotsaver.cpp" line="73"/>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="76"/>
         <source>Save Error</source>
         <translation>Hata Kaydet</translation>
     </message>
     <message>
-        <location filename="../src/capture/workers/screenshotsaver.cpp" line="45"/>
-        <location filename="../src/capture/workers/screenshotsaver.cpp" line="67"/>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="48"/>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="70"/>
         <source>Capture saved as </source>
         <translation>Yakalanma şu şekilde kaydedildi </translation>
     </message>
     <message>
-        <location filename="../src/capture/workers/screenshotsaver.cpp" line="47"/>
-        <location filename="../src/capture/workers/screenshotsaver.cpp" line="70"/>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="35"/>
+        <source>Capture saved to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="50"/>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="73"/>
         <source>Error trying to save as </source>
         <translation>Olarak kaydedilmeye çalışılırken hata oluştu </translation>
     </message>

--- a/translations/Internationalization_zh_CN.ts
+++ b/translations/Internationalization_zh_CN.ts
@@ -135,17 +135,17 @@ Use the Mouse Wheel to change the thickness of your tool.</source>
     <message>
         <location filename="../src/core/controller.cpp" line="109"/>
         <source>&amp;Configuration</source>
-        <translation>&amp;配置</translation>
+        <translation>配置(&amp;C)</translation>
     </message>
     <message>
         <location filename="../src/core/controller.cpp" line="112"/>
         <source>&amp;Information</source>
-        <translation>&amp;信息</translation>
+        <translation>信息(&amp;I)</translation>
     </message>
     <message>
         <location filename="../src/core/controller.cpp" line="115"/>
         <source>&amp;Quit</source>
-        <translation>&amp;退出</translation>
+        <translation>退出(&amp;Q)</translation>
     </message>
 </context>
 <context>
@@ -166,7 +166,7 @@ Use the Mouse Wheel to change the thickness of your tool.</source>
     <message>
         <location filename="../src/utils/dbusutils.cpp" line="35"/>
         <source>Unable to connect via DBus</source>
-        <translation>无法通过Dbus进行连接</translation>
+        <translation>无法通过DBus进行连接</translation>
     </message>
 </context>
 <context>
@@ -336,7 +336,7 @@ Use the Mouse Wheel to change the thickness of your tool.</source>
     <message>
         <location filename="../src/config/geneneralconf.cpp" line="191"/>
         <source>Launch Flameshot</source>
-        <translation type="unfinished"></translation>
+        <translation>启动 Flameshot</translation>
     </message>
 </context>
 <context>
@@ -465,12 +465,12 @@ Use the Mouse Wheel to change the thickness of your tool.</source>
     <message>
         <location filename="../src/infowindow.cpp" line="97"/>
         <source>&lt;u&gt;&lt;b&gt;License&lt;/b&gt;&lt;/u&gt;</source>
-        <translation>&lt;u&gt;&lt;b&gt;License&lt;/b&gt;&lt;/u&gt;</translation>
+        <translation>&lt;u&gt;&lt;b&gt;许可证&lt;/b&gt;&lt;/u&gt;</translation>
     </message>
     <message>
         <location filename="../src/infowindow.cpp" line="105"/>
         <source>&lt;u&gt;&lt;b&gt;Version&lt;/b&gt;&lt;/u&gt;</source>
-        <translation>&lt;u&gt;&lt;b&gt;Version&lt;/b&gt;&lt;/u&gt;</translation>
+        <translation>&lt;u&gt;&lt;b&gt;版本&lt;/b&gt;&lt;/u&gt;</translation>
     </message>
     <message>
         <location filename="../src/infowindow.cpp" line="115"/>
@@ -538,19 +538,24 @@ Use the Mouse Wheel to change the thickness of your tool.</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/capture/workers/screenshotsaver.cpp" line="73"/>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="76"/>
         <source>Save Error</source>
         <translation>保存错误</translation>
     </message>
     <message>
-        <location filename="../src/capture/workers/screenshotsaver.cpp" line="45"/>
-        <location filename="../src/capture/workers/screenshotsaver.cpp" line="67"/>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="48"/>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="70"/>
         <source>Capture saved as </source>
-        <translation>捕获保存为 </translation>
+        <translation>捕获已保存为 </translation>
     </message>
     <message>
-        <location filename="../src/capture/workers/screenshotsaver.cpp" line="47"/>
-        <location filename="../src/capture/workers/screenshotsaver.cpp" line="70"/>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="35"/>
+        <source>Capture saved to clipboard</source>
+        <translation>捕获已保存至剪贴板</translation>
+    </message>
+    <message>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="50"/>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="73"/>
         <source>Error trying to save as </source>
         <translation>尝试另存为时出错 </translation>
     </message>
@@ -747,7 +752,7 @@ Use the Mouse Wheel to change the thickness of your tool.</source>
     <message>
         <location filename="../src/config/uicoloreditor.cpp" line="102"/>
         <source>Select a Button to modify it</source>
-        <translation>选择一个按钮来修改它</translation>
+        <translation>选择一个按钮以进行修改</translation>
     </message>
     <message>
         <location filename="../src/config/uicoloreditor.cpp" line="111"/>

--- a/translations/Internationalization_zh_TW.ts
+++ b/translations/Internationalization_zh_TW.ts
@@ -537,19 +537,24 @@ Use the Mouse Wheel to change the thickness of your tool.</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/capture/workers/screenshotsaver.cpp" line="73"/>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="76"/>
         <source>Save Error</source>
         <translation>存檔錯誤</translation>
     </message>
     <message>
-        <location filename="../src/capture/workers/screenshotsaver.cpp" line="45"/>
-        <location filename="../src/capture/workers/screenshotsaver.cpp" line="67"/>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="48"/>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="70"/>
         <source>Capture saved as </source>
         <translation>截圖已另存為 </translation>
     </message>
     <message>
-        <location filename="../src/capture/workers/screenshotsaver.cpp" line="47"/>
-        <location filename="../src/capture/workers/screenshotsaver.cpp" line="70"/>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="35"/>
+        <source>Capture saved to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="50"/>
+        <location filename="../src/capture/workers/screenshotsaver.cpp" line="73"/>
         <source>Error trying to save as </source>
         <translation>嘗試另存新檔時發生錯誤 </translation>
     </message>


### PR DESCRIPTION
After reading #160 , I believe it might be necessary to notice users when the capture is saved in clipboard. This pull request would make flameshot pop up desktop notification whenever the screenshot is saved in system clipboard.

Translation files are also updated based on the lastest source code.