### PR TITLE
systemnotification: Fix wrong icon name

### DIFF
--- a/src/utils/systemnotification.cpp
+++ b/src/utils/systemnotification.cpp
@@ -37,7 +37,7 @@ void SystemNotification::sendMessage(
     QList<QVariant> args;
     args << (qAppName())                 //appname
          << static_cast<unsigned int>(0) //id
-         << "flameshot.png"              //icon
+         << "flameshot"                  //icon
          << title                        //summary
          << text                         //body
          << QStringList()                //actions


### PR DESCRIPTION
Current implementation of SystemNotification::sendMessage()
is wrongly using "flameshot.png" as icon name.

We should strip the suffix and directly use "flameshot" to comply
with Desktop Notification Specification.

This commit does so and indeed makes notifications show flameshot
icon on GNOME Shell again.

See also https://developer.gnome.org/notification-spec/ .