### PR TITLE
fix translations files path

### DIFF
--- a/.travis_linux.sh
+++ b/.travis_linux.sh
@@ -85,6 +85,7 @@ elif [[ "${DIST}" == "trusty" ]]; then
     cp /usr/lib/x86_64-linux-gnu/qt5/plugins/platforminputcontexts/libfcitxplatforminputcontextplugin.so $APPIMAGE_DST_PATH/appdir/usr/plugins/platforminputcontexts/
     cd $APPIMAGE_DST_PATH/appdir/usr/bin
 	ln -sf ../plugins/platforms/ .   # An unknown bug
+	ln -sf ../share/flameshot/translations/ . # add translation soft link 
     cd ${project_dir}
 
     # -verbose=2

--- a/src/utils/pathinfo.cpp
+++ b/src/utils/pathinfo.cpp
@@ -29,9 +29,9 @@ const QString PathInfo::blackIconPath() {
 }
 
 QStringList PathInfo::translationsPaths() {
-    QString binaryPath = QFileInfo(qApp->applicationFilePath())
+    QString binaryPath = QFileInfo(qApp->applicationDirPath())
             .absoluteFilePath();
-    QString trPath = QDir::toNativeSeparators(binaryPath) + "translations";
+    QString trPath = QDir::toNativeSeparators(binaryPath + "/translations") ;
 #if defined(Q_OS_LINUX)
     return QStringList()
             << QString(APP_PREFIX) + "/share/flameshot/translations"


### PR DESCRIPTION
Under Windows and Linux AppImage enviroment, fix translations files path.