### PR TITLE
Improvement of Pin tool

### DIFF
--- a/src/tools/pin/pintool.cpp
+++ b/src/tools/pin/pintool.cpp
@@ -44,7 +44,11 @@ QString PinTool::description() const {
 
 QWidget* PinTool::widget() {
     PinWidget *w = new PinWidget(m_pixmap);
-    w->setGeometry(m_geometry);
+    QRect adjusted_pos = QRect (m_geometry.left() - LAYOUT_MARGIN,
+                                m_geometry.top() - LAYOUT_MARGIN,
+                                m_geometry.width() + 2 * LAYOUT_MARGIN,
+                                m_geometry.height() + 2 * LAYOUT_MARGIN);
+    w->setGeometry(adjusted_pos);
     return w;
 }
 

--- a/src/tools/pin/pinwidget.cpp
+++ b/src/tools/pin/pinwidget.cpp
@@ -26,8 +26,19 @@ PinWidget::PinWidget(const QPixmap &pixmap, QWidget *parent) :
     QWidget(parent), m_pixmap(pixmap)
 {
     setWindowFlags(Qt::WindowStaysOnTopHint
-                   | Qt::FramelessWindowHint);
+                   | Qt::FramelessWindowHint
+                   | Qt::Tool
+                   | Qt::X11BypassWindowManagerHint);
+    //set the bottom widget background transparent
+    setAttribute(Qt::WA_TranslucentBackground);
+
+    m_shadowEffect->setColor(Qt::lightGray);
+    m_shadowEffect->setBlurRadius(2 * LAYOUT_MARGIN);
+    m_shadowEffect->setOffset(0, 0);
+    setGraphicsEffect(m_shadowEffect);
+
     m_layout = new QVBoxLayout(this);
+    m_layout->setContentsMargins(LAYOUT_MARGIN, LAYOUT_MARGIN, LAYOUT_MARGIN, LAYOUT_MARGIN);
 
     m_label = new QLabel();
     m_label->setPixmap(m_pixmap);
@@ -47,6 +58,13 @@ void PinWidget::wheelEvent(QWheelEvent *e) {
     adjustSize();
 
     e->accept();
+}
+
+void PinWidget::enterEvent(QEvent *) {
+    m_shadowEffect->setColor(QColor(3, 150, 255));
+}
+void PinWidget::leaveEvent(QEvent *) {
+    m_shadowEffect->setColor(Qt::lightGray);
 }
 
 void PinWidget::mouseDoubleClickEvent(QMouseEvent *) {

--- a/src/tools/pin/pinwidget.h
+++ b/src/tools/pin/pinwidget.h
@@ -18,6 +18,9 @@
 #pragma once
 
 #include <QWidget>
+#include <QGraphicsDropShadowEffect>
+
+#define LAYOUT_MARGIN 7
 
 class QVBoxLayout;
 class QLabel;
@@ -32,6 +35,8 @@ protected:
     void mouseDoubleClickEvent(QMouseEvent *);
     void mousePressEvent(QMouseEvent *);
     void mouseMoveEvent(QMouseEvent *);
+    void enterEvent(QEvent *);
+    void leaveEvent(QEvent *);
 
 private:
     void setScaledPixmap(const QSize &size);
@@ -41,4 +46,5 @@ private:
     QLabel *m_label;
     QPoint m_dragStart;
     qreal m_offsetX, m_offsetY;
+    QGraphicsDropShadowEffect *m_shadowEffect = new QGraphicsDropShadowEffect(this);
 };


### PR DESCRIPTION
- no taskbar window for pin widget
- completely ignore the window manager
- add borderless window shadow effects

For shadow effects, there is a QT bug(Affects Version is 5.6.0, 5.9.3, 5.9.4):
https://bugreports.qt.io/browse/QTBUG-58602
It only appears on Windows system, eg. Windows 8,10.

![peek 2018-04-17 19-03](https://user-images.githubusercontent.com/10769951/38867500-d156c40c-4276-11e8-9865-ff30a0b701fe.gif)
