### PR TITLE
Another attempt to fix zh_CN translation

### DIFF
--- a/translations/Internationalization_ca.ts
+++ b/translations/Internationalization_ca.ts
@@ -123,6 +123,10 @@ Utilitzeu la roda del ratolí per a canviar el gruix de l&apos;eina.</translatio
         <source>&amp;Quit</source>
         <translation>&amp;Ix</translation>
     </message>
+    <message>
+        <source>&amp;Take Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>CopyTool</name>
@@ -439,6 +443,17 @@ Utilitzeu la roda del ratolí per a canviar el gruix de l&apos;eina.</translatio
     </message>
 </context>
 <context>
+    <name>PinTool</name>
+    <message>
+        <source>Pin Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pin image on the desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
     <message>
         <source>Save Error</source>
@@ -605,6 +620,13 @@ Utilitzeu la roda del ratolí per a canviar el gruix de l&apos;eina.</translatio
     <message>
         <source>Full Date (%Y-%m-%d)</source>
         <translation>Data (%Y-%m-%d)</translation>
+    </message>
+</context>
+<context>
+    <name>SystemNotification</name>
+    <message>
+        <source>Flameshot Info</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/Internationalization_es.ts
+++ b/translations/Internationalization_es.ts
@@ -77,12 +77,12 @@
 <context>
     <name>CaptureWidget</name>
     <message>
-        <location filename="../src/widgets/capture/capturewidget.cpp" line="97"/>
+        <location filename="../src/widgets/capture/capturewidget.cpp" line="79"/>
         <source>Unable to capture screen</source>
         <translation>Imposible capturar la pantalla</translation>
     </message>
     <message>
-        <location filename="../src/widgets/capture/capturewidget.cpp" line="221"/>
+        <location filename="../src/widgets/capture/capturewidget.cpp" line="215"/>
         <source>Select an area with the mouse, or press Esc to exit.
 Press Enter to capture the screen.
 Press Right Click to show the color picker.
@@ -132,17 +132,22 @@ Usa la rueda del ratón para cambiar el grosor de la herramienta.</translation>
 <context>
     <name>Controller</name>
     <message>
-        <location filename="../src/core/controller.cpp" line="108"/>
+        <location filename="../src/core/controller.cpp" line="109"/>
+        <source>&amp;Take Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/controller.cpp" line="114"/>
         <source>&amp;Configuration</source>
         <translation>&amp;Configuración</translation>
     </message>
     <message>
-        <location filename="../src/core/controller.cpp" line="111"/>
+        <location filename="../src/core/controller.cpp" line="117"/>
         <source>&amp;Information</source>
         <translation>&amp;Información</translation>
     </message>
     <message>
-        <location filename="../src/core/controller.cpp" line="114"/>
+        <location filename="../src/core/controller.cpp" line="120"/>
         <source>&amp;Quit</source>
         <translation>&amp;Salir</translation>
     </message>
@@ -239,7 +244,7 @@ Usa la rueda del ratón para cambiar el grosor de la herramienta.</translation>
 <context>
     <name>FlameshotDBusAdapter</name>
     <message>
-        <location filename="../src/core/flameshotdbusadapter.cpp" line="74"/>
+        <location filename="../src/core/flameshotdbusadapter.cpp" line="57"/>
         <source>Unable to capture screen</source>
         <translation>Imposible capturar la pantalla</translation>
     </message>
@@ -534,6 +539,19 @@ Usa la rueda del ratón para cambiar el grosor de la herramienta.</translation>
     </message>
 </context>
 <context>
+    <name>PinTool</name>
+    <message>
+        <location filename="../src/tools/pin/pintool.cpp" line="34"/>
+        <source>Pin Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/pin/pintool.cpp" line="42"/>
+        <source>Pin image on the desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
     <message>
         <location filename="../src/utils/screenshotsaver.cpp" line="75"/>
@@ -559,8 +577,9 @@ Usa la rueda del ratón para cambiar el grosor de la herramienta.</translation>
     </message>
     <message>
         <location filename="../src/main.cpp" line="71"/>
-        <location filename="../src/main.cpp" line="304"/>
-        <location filename="../src/main.cpp" line="333"/>
+        <location filename="../src/main.cpp" line="302"/>
+        <location filename="../src/main.cpp" line="326"/>
+        <location filename="../src/main.cpp" line="355"/>
         <source>Unable to connect via DBus</source>
         <translation>Imposible conectar mediante DBus</translation>
     </message>
@@ -741,6 +760,14 @@ Usa la rueda del ratón para cambiar el grosor de la herramienta.</translation>
         <location filename="../src/config/strftimechooserwidget.cpp" line="67"/>
         <source>Full Date (%Y-%m-%d)</source>
         <translation>Fecha (%Y-%m-%d)</translation>
+    </message>
+</context>
+<context>
+    <name>SystemNotification</name>
+    <message>
+        <location filename="../src/utils/systemnotification.cpp" line="28"/>
+        <source>Flameshot Info</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/Internationalization_fr.ts
+++ b/translations/Internationalization_fr.ts
@@ -77,12 +77,12 @@
 <context>
     <name>CaptureWidget</name>
     <message>
-        <location filename="../src/widgets/capture/capturewidget.cpp" line="97"/>
+        <location filename="../src/widgets/capture/capturewidget.cpp" line="79"/>
         <source>Unable to capture screen</source>
         <translation>Imposible de capturer l&apos;écran</translation>
     </message>
     <message>
-        <location filename="../src/widgets/capture/capturewidget.cpp" line="221"/>
+        <location filename="../src/widgets/capture/capturewidget.cpp" line="215"/>
         <source>Select an area with the mouse, or press Esc to exit.
 Press Enter to capture the screen.
 Press Right Click to show the color picker.
@@ -132,17 +132,22 @@ Utiliser la molette pour changer l&apos;épaisseur de l&apos;outil.</translation
 <context>
     <name>Controller</name>
     <message>
-        <location filename="../src/core/controller.cpp" line="108"/>
+        <location filename="../src/core/controller.cpp" line="109"/>
+        <source>&amp;Take Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/controller.cpp" line="114"/>
         <source>&amp;Configuration</source>
         <translation>&amp;Configuration</translation>
     </message>
     <message>
-        <location filename="../src/core/controller.cpp" line="111"/>
+        <location filename="../src/core/controller.cpp" line="117"/>
         <source>&amp;Information</source>
         <translation>&amp;Information</translation>
     </message>
     <message>
-        <location filename="../src/core/controller.cpp" line="114"/>
+        <location filename="../src/core/controller.cpp" line="120"/>
         <source>&amp;Quit</source>
         <translation>&amp;Quitter</translation>
     </message>
@@ -239,7 +244,7 @@ Utiliser la molette pour changer l&apos;épaisseur de l&apos;outil.</translation
 <context>
     <name>FlameshotDBusAdapter</name>
     <message>
-        <location filename="../src/core/flameshotdbusadapter.cpp" line="74"/>
+        <location filename="../src/core/flameshotdbusadapter.cpp" line="57"/>
         <source>Unable to capture screen</source>
         <translation>Impossible de capturer l&apos;écran</translation>
     </message>
@@ -534,6 +539,19 @@ Utiliser la molette pour changer l&apos;épaisseur de l&apos;outil.</translation
     </message>
 </context>
 <context>
+    <name>PinTool</name>
+    <message>
+        <location filename="../src/tools/pin/pintool.cpp" line="34"/>
+        <source>Pin Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/pin/pintool.cpp" line="42"/>
+        <source>Pin image on the desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
     <message>
         <location filename="../src/utils/screenshotsaver.cpp" line="75"/>
@@ -559,8 +577,9 @@ Utiliser la molette pour changer l&apos;épaisseur de l&apos;outil.</translation
     </message>
     <message>
         <location filename="../src/main.cpp" line="71"/>
-        <location filename="../src/main.cpp" line="304"/>
-        <location filename="../src/main.cpp" line="333"/>
+        <location filename="../src/main.cpp" line="302"/>
+        <location filename="../src/main.cpp" line="326"/>
+        <location filename="../src/main.cpp" line="355"/>
         <source>Unable to connect via DBus</source>
         <translation>Impossible de se connecter via DBus</translation>
     </message>
@@ -741,6 +760,14 @@ Utiliser la molette pour changer l&apos;épaisseur de l&apos;outil.</translation
         <location filename="../src/config/strftimechooserwidget.cpp" line="67"/>
         <source>Full Date (%Y-%m-%d)</source>
         <translation>Date Complête (%Y-%m-%d)</translation>
+    </message>
+</context>
+<context>
+    <name>SystemNotification</name>
+    <message>
+        <location filename="../src/utils/systemnotification.cpp" line="28"/>
+        <source>Flameshot Info</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/Internationalization_ka.ts
+++ b/translations/Internationalization_ka.ts
@@ -77,12 +77,12 @@
 <context>
     <name>CaptureWidget</name>
     <message>
-        <location filename="../src/widgets/capture/capturewidget.cpp" line="97"/>
+        <location filename="../src/widgets/capture/capturewidget.cpp" line="79"/>
         <source>Unable to capture screen</source>
         <translation>ეკრანის გადაღება ვერ მოხერხდა</translation>
     </message>
     <message>
-        <location filename="../src/widgets/capture/capturewidget.cpp" line="221"/>
+        <location filename="../src/widgets/capture/capturewidget.cpp" line="215"/>
         <source>Select an area with the mouse, or press Esc to exit.
 Press Enter to capture the screen.
 Press Right Click to show the color picker.
@@ -132,17 +132,22 @@ Use the Mouse Wheel to change the thickness of your tool.</source>
 <context>
     <name>Controller</name>
     <message>
-        <location filename="../src/core/controller.cpp" line="108"/>
+        <location filename="../src/core/controller.cpp" line="109"/>
+        <source>&amp;Take Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/controller.cpp" line="114"/>
         <source>&amp;Configuration</source>
         <translation>&amp;პარამეტრები</translation>
     </message>
     <message>
-        <location filename="../src/core/controller.cpp" line="111"/>
+        <location filename="../src/core/controller.cpp" line="117"/>
         <source>&amp;Information</source>
         <translation>&amp;ინფორმაცია</translation>
     </message>
     <message>
-        <location filename="../src/core/controller.cpp" line="114"/>
+        <location filename="../src/core/controller.cpp" line="120"/>
         <source>&amp;Quit</source>
         <translation>&amp;გამოსვლა</translation>
     </message>
@@ -239,7 +244,7 @@ Use the Mouse Wheel to change the thickness of your tool.</source>
 <context>
     <name>FlameshotDBusAdapter</name>
     <message>
-        <location filename="../src/core/flameshotdbusadapter.cpp" line="74"/>
+        <location filename="../src/core/flameshotdbusadapter.cpp" line="57"/>
         <source>Unable to capture screen</source>
         <translation>ეკრანის გადაღება ვერ მოხერხდა</translation>
     </message>
@@ -534,6 +539,19 @@ Use the Mouse Wheel to change the thickness of your tool.</source>
     </message>
 </context>
 <context>
+    <name>PinTool</name>
+    <message>
+        <location filename="../src/tools/pin/pintool.cpp" line="34"/>
+        <source>Pin Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/pin/pintool.cpp" line="42"/>
+        <source>Pin image on the desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
     <message>
         <location filename="../src/utils/screenshotsaver.cpp" line="75"/>
@@ -559,8 +577,9 @@ Use the Mouse Wheel to change the thickness of your tool.</source>
     </message>
     <message>
         <location filename="../src/main.cpp" line="71"/>
-        <location filename="../src/main.cpp" line="304"/>
-        <location filename="../src/main.cpp" line="333"/>
+        <location filename="../src/main.cpp" line="302"/>
+        <location filename="../src/main.cpp" line="326"/>
+        <location filename="../src/main.cpp" line="355"/>
         <source>Unable to connect via DBus</source>
         <translation>DBus-ით დაკავშირება ვერ მოხერხდა</translation>
     </message>
@@ -741,6 +760,14 @@ Use the Mouse Wheel to change the thickness of your tool.</source>
         <location filename="../src/config/strftimechooserwidget.cpp" line="67"/>
         <source>Full Date (%Y-%m-%d)</source>
         <translation>სრული თარიღი (%Y-%m-%d)</translation>
+    </message>
+</context>
+<context>
+    <name>SystemNotification</name>
+    <message>
+        <location filename="../src/utils/systemnotification.cpp" line="28"/>
+        <source>Flameshot Info</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/Internationalization_pl.ts
+++ b/translations/Internationalization_pl.ts
@@ -77,12 +77,12 @@
 <context>
     <name>CaptureWidget</name>
     <message>
-        <location filename="../src/widgets/capture/capturewidget.cpp" line="97"/>
+        <location filename="../src/widgets/capture/capturewidget.cpp" line="79"/>
         <source>Unable to capture screen</source>
         <translation>Nie można przechwycić ekranu</translation>
     </message>
     <message>
-        <location filename="../src/widgets/capture/capturewidget.cpp" line="221"/>
+        <location filename="../src/widgets/capture/capturewidget.cpp" line="215"/>
         <source>Select an area with the mouse, or press Esc to exit.
 Press Enter to capture the screen.
 Press Right Click to show the color picker.
@@ -132,17 +132,22 @@ Użyj kółka myszy, aby zmienić grubość narzędzia do rysowania.</translatio
 <context>
     <name>Controller</name>
     <message>
-        <location filename="../src/core/controller.cpp" line="108"/>
+        <location filename="../src/core/controller.cpp" line="109"/>
+        <source>&amp;Take Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/controller.cpp" line="114"/>
         <source>&amp;Configuration</source>
         <translation>&amp;Konfiguracja</translation>
     </message>
     <message>
-        <location filename="../src/core/controller.cpp" line="111"/>
+        <location filename="../src/core/controller.cpp" line="117"/>
         <source>&amp;Information</source>
         <translation>&amp;Informacje</translation>
     </message>
     <message>
-        <location filename="../src/core/controller.cpp" line="114"/>
+        <location filename="../src/core/controller.cpp" line="120"/>
         <source>&amp;Quit</source>
         <translation>&amp;Wyjdź</translation>
     </message>
@@ -239,7 +244,7 @@ Użyj kółka myszy, aby zmienić grubość narzędzia do rysowania.</translatio
 <context>
     <name>FlameshotDBusAdapter</name>
     <message>
-        <location filename="../src/core/flameshotdbusadapter.cpp" line="74"/>
+        <location filename="../src/core/flameshotdbusadapter.cpp" line="57"/>
         <source>Unable to capture screen</source>
         <translation>Nie można przechwycić ekranu</translation>
     </message>
@@ -534,6 +539,19 @@ Użyj kółka myszy, aby zmienić grubość narzędzia do rysowania.</translatio
     </message>
 </context>
 <context>
+    <name>PinTool</name>
+    <message>
+        <location filename="../src/tools/pin/pintool.cpp" line="34"/>
+        <source>Pin Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/pin/pintool.cpp" line="42"/>
+        <source>Pin image on the desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
     <message>
         <location filename="../src/utils/screenshotsaver.cpp" line="75"/>
@@ -559,8 +577,9 @@ Użyj kółka myszy, aby zmienić grubość narzędzia do rysowania.</translatio
     </message>
     <message>
         <location filename="../src/main.cpp" line="71"/>
-        <location filename="../src/main.cpp" line="304"/>
-        <location filename="../src/main.cpp" line="333"/>
+        <location filename="../src/main.cpp" line="302"/>
+        <location filename="../src/main.cpp" line="326"/>
+        <location filename="../src/main.cpp" line="355"/>
         <source>Unable to connect via DBus</source>
         <translation>Nie udało się połączyć za pomocą DBus</translation>
     </message>
@@ -741,6 +760,14 @@ Użyj kółka myszy, aby zmienić grubość narzędzia do rysowania.</translatio
         <location filename="../src/config/strftimechooserwidget.cpp" line="67"/>
         <source>Full Date (%Y-%m-%d)</source>
         <translation>Data (%Y-%m-%d)</translation>
+    </message>
+</context>
+<context>
+    <name>SystemNotification</name>
+    <message>
+        <location filename="../src/utils/systemnotification.cpp" line="28"/>
+        <source>Flameshot Info</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/Internationalization_ru.ts
+++ b/translations/Internationalization_ru.ts
@@ -77,12 +77,12 @@
 <context>
     <name>CaptureWidget</name>
     <message>
-        <location filename="../src/widgets/capture/capturewidget.cpp" line="97"/>
+        <location filename="../src/widgets/capture/capturewidget.cpp" line="79"/>
         <source>Unable to capture screen</source>
         <translation>Не удалось захватить экран</translation>
     </message>
     <message>
-        <location filename="../src/widgets/capture/capturewidget.cpp" line="221"/>
+        <location filename="../src/widgets/capture/capturewidget.cpp" line="215"/>
         <source>Select an area with the mouse, or press Esc to exit.
 Press Enter to capture the screen.
 Press Right Click to show the color picker.
@@ -132,17 +132,22 @@ Use the Mouse Wheel to change the thickness of your tool.</source>
 <context>
     <name>Controller</name>
     <message>
-        <location filename="../src/core/controller.cpp" line="108"/>
+        <location filename="../src/core/controller.cpp" line="109"/>
+        <source>&amp;Take Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/controller.cpp" line="114"/>
         <source>&amp;Configuration</source>
         <translation>&amp;Настройка</translation>
     </message>
     <message>
-        <location filename="../src/core/controller.cpp" line="111"/>
+        <location filename="../src/core/controller.cpp" line="117"/>
         <source>&amp;Information</source>
         <translation>&amp;Информация</translation>
     </message>
     <message>
-        <location filename="../src/core/controller.cpp" line="114"/>
+        <location filename="../src/core/controller.cpp" line="120"/>
         <source>&amp;Quit</source>
         <translation>&amp;Выход</translation>
     </message>
@@ -239,7 +244,7 @@ Use the Mouse Wheel to change the thickness of your tool.</source>
 <context>
     <name>FlameshotDBusAdapter</name>
     <message>
-        <location filename="../src/core/flameshotdbusadapter.cpp" line="74"/>
+        <location filename="../src/core/flameshotdbusadapter.cpp" line="57"/>
         <source>Unable to capture screen</source>
         <translation>Не удается захватить экран</translation>
     </message>
@@ -534,6 +539,19 @@ Use the Mouse Wheel to change the thickness of your tool.</source>
     </message>
 </context>
 <context>
+    <name>PinTool</name>
+    <message>
+        <location filename="../src/tools/pin/pintool.cpp" line="34"/>
+        <source>Pin Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/pin/pintool.cpp" line="42"/>
+        <source>Pin image on the desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
     <message>
         <location filename="../src/utils/screenshotsaver.cpp" line="75"/>
@@ -559,8 +577,9 @@ Use the Mouse Wheel to change the thickness of your tool.</source>
     </message>
     <message>
         <location filename="../src/main.cpp" line="71"/>
-        <location filename="../src/main.cpp" line="304"/>
-        <location filename="../src/main.cpp" line="333"/>
+        <location filename="../src/main.cpp" line="302"/>
+        <location filename="../src/main.cpp" line="326"/>
+        <location filename="../src/main.cpp" line="355"/>
         <source>Unable to connect via DBus</source>
         <translation>Не удалось подключиться через DBus</translation>
     </message>
@@ -741,6 +760,14 @@ Use the Mouse Wheel to change the thickness of your tool.</source>
         <location filename="../src/config/strftimechooserwidget.cpp" line="67"/>
         <source>Full Date (%Y-%m-%d)</source>
         <translation>Полная дата  (%Y-%m-%d)</translation>
+    </message>
+</context>
+<context>
+    <name>SystemNotification</name>
+    <message>
+        <location filename="../src/utils/systemnotification.cpp" line="28"/>
+        <source>Flameshot Info</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/Internationalization_tr.ts
+++ b/translations/Internationalization_tr.ts
@@ -77,12 +77,12 @@
 <context>
     <name>CaptureWidget</name>
     <message>
-        <location filename="../src/widgets/capture/capturewidget.cpp" line="97"/>
+        <location filename="../src/widgets/capture/capturewidget.cpp" line="79"/>
         <source>Unable to capture screen</source>
         <translation>Ekran yakalanamadı</translation>
     </message>
     <message>
-        <location filename="../src/widgets/capture/capturewidget.cpp" line="221"/>
+        <location filename="../src/widgets/capture/capturewidget.cpp" line="215"/>
         <source>Select an area with the mouse, or press Esc to exit.
 Press Enter to capture the screen.
 Press Right Click to show the color picker.
@@ -132,17 +132,22 @@ Araç boyutunu değiştirmek için Fare tekerleğini kullanın.</translation>
 <context>
     <name>Controller</name>
     <message>
-        <location filename="../src/core/controller.cpp" line="108"/>
+        <location filename="../src/core/controller.cpp" line="109"/>
+        <source>&amp;Take Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/controller.cpp" line="114"/>
         <source>&amp;Configuration</source>
         <translation>&amp;Ayarlar</translation>
     </message>
     <message>
-        <location filename="../src/core/controller.cpp" line="111"/>
+        <location filename="../src/core/controller.cpp" line="117"/>
         <source>&amp;Information</source>
         <translation>&amp;Bilgi</translation>
     </message>
     <message>
-        <location filename="../src/core/controller.cpp" line="114"/>
+        <location filename="../src/core/controller.cpp" line="120"/>
         <source>&amp;Quit</source>
         <translation>&amp;Çıkış</translation>
     </message>
@@ -239,7 +244,7 @@ Araç boyutunu değiştirmek için Fare tekerleğini kullanın.</translation>
 <context>
     <name>FlameshotDBusAdapter</name>
     <message>
-        <location filename="../src/core/flameshotdbusadapter.cpp" line="74"/>
+        <location filename="../src/core/flameshotdbusadapter.cpp" line="57"/>
         <source>Unable to capture screen</source>
         <translation>Ekran yakalanamadı</translation>
     </message>
@@ -534,6 +539,19 @@ Araç boyutunu değiştirmek için Fare tekerleğini kullanın.</translation>
     </message>
 </context>
 <context>
+    <name>PinTool</name>
+    <message>
+        <location filename="../src/tools/pin/pintool.cpp" line="34"/>
+        <source>Pin Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/pin/pintool.cpp" line="42"/>
+        <source>Pin image on the desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
     <message>
         <location filename="../src/utils/screenshotsaver.cpp" line="75"/>
@@ -559,8 +577,9 @@ Araç boyutunu değiştirmek için Fare tekerleğini kullanın.</translation>
     </message>
     <message>
         <location filename="../src/main.cpp" line="71"/>
-        <location filename="../src/main.cpp" line="304"/>
-        <location filename="../src/main.cpp" line="333"/>
+        <location filename="../src/main.cpp" line="302"/>
+        <location filename="../src/main.cpp" line="326"/>
+        <location filename="../src/main.cpp" line="355"/>
         <source>Unable to connect via DBus</source>
         <translation>DBus ile bağlanılamadı</translation>
     </message>
@@ -741,6 +760,14 @@ Araç boyutunu değiştirmek için Fare tekerleğini kullanın.</translation>
         <location filename="../src/config/strftimechooserwidget.cpp" line="67"/>
         <source>Full Date (%Y-%m-%d)</source>
         <translation>Tam Tarih (%d-%m-%Y)</translation>
+    </message>
+</context>
+<context>
+    <name>SystemNotification</name>
+    <message>
+        <location filename="../src/utils/systemnotification.cpp" line="28"/>
+        <source>Flameshot Info</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/Internationalization_zh_CN.ts
+++ b/translations/Internationalization_zh_CN.ts
@@ -77,7 +77,7 @@
 <context>
     <name>CaptureWidget</name>
     <message>
-        <location filename="../src/widgets/capture/capturewidget.cpp" line="221"/>
+        <location filename="../src/widgets/capture/capturewidget.cpp" line="215"/>
         <source>Select an area with the mouse, or press Esc to exit.
 Press Enter to capture the screen.
 Press Right Click to show the color picker.
@@ -88,7 +88,7 @@ Use the Mouse Wheel to change the thickness of your tool.</source>
 使用鼠标滚轮来改变油漆工具的厚度。</translation>
     </message>
     <message>
-        <location filename="../src/widgets/capture/capturewidget.cpp" line="97"/>
+        <location filename="../src/widgets/capture/capturewidget.cpp" line="79"/>
         <source>Unable to capture screen</source>
         <translatorcomment>无法捕获屏幕</translatorcomment>
         <translation>无法捕获屏幕</translation>
@@ -133,17 +133,22 @@ Use the Mouse Wheel to change the thickness of your tool.</source>
 <context>
     <name>Controller</name>
     <message>
-        <location filename="../src/core/controller.cpp" line="108"/>
+        <location filename="../src/core/controller.cpp" line="109"/>
+        <source>&amp;Take Screenshot</source>
+        <translation>进行截图(&amp;T)</translation>
+    </message>
+    <message>
+        <location filename="../src/core/controller.cpp" line="114"/>
         <source>&amp;Configuration</source>
         <translation>配置(&amp;C)</translation>
     </message>
     <message>
-        <location filename="../src/core/controller.cpp" line="111"/>
+        <location filename="../src/core/controller.cpp" line="117"/>
         <source>&amp;Information</source>
         <translation>信息(&amp;I)</translation>
     </message>
     <message>
-        <location filename="../src/core/controller.cpp" line="114"/>
+        <location filename="../src/core/controller.cpp" line="120"/>
         <source>&amp;Quit</source>
         <translation>退出(&amp;Q)</translation>
     </message>
@@ -240,7 +245,7 @@ Use the Mouse Wheel to change the thickness of your tool.</source>
 <context>
     <name>FlameshotDBusAdapter</name>
     <message>
-        <location filename="../src/core/flameshotdbusadapter.cpp" line="74"/>
+        <location filename="../src/core/flameshotdbusadapter.cpp" line="57"/>
         <source>Unable to capture screen</source>
         <translation>无法捕获屏幕</translation>
     </message>
@@ -535,6 +540,19 @@ Use the Mouse Wheel to change the thickness of your tool.</source>
     </message>
 </context>
 <context>
+    <name>PinTool</name>
+    <message>
+        <location filename="../src/tools/pin/pintool.cpp" line="34"/>
+        <source>Pin Tool</source>
+        <translation>贴图工具</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/pin/pintool.cpp" line="42"/>
+        <source>Pin image on the desktop</source>
+        <translation>在桌面上固定图像</translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
     <message>
         <location filename="../src/utils/screenshotsaver.cpp" line="75"/>
@@ -560,8 +578,9 @@ Use the Mouse Wheel to change the thickness of your tool.</source>
     </message>
     <message>
         <location filename="../src/main.cpp" line="71"/>
-        <location filename="../src/main.cpp" line="304"/>
-        <location filename="../src/main.cpp" line="333"/>
+        <location filename="../src/main.cpp" line="302"/>
+        <location filename="../src/main.cpp" line="326"/>
+        <location filename="../src/main.cpp" line="355"/>
         <source>Unable to connect via DBus</source>
         <translation>无法通过DBus进行连接</translation>
     </message>
@@ -742,6 +761,14 @@ Use the Mouse Wheel to change the thickness of your tool.</source>
         <location filename="../src/config/strftimechooserwidget.cpp" line="67"/>
         <source>Full Date (%Y-%m-%d)</source>
         <translation>日期 (%Y-%m-%d)</translation>
+    </message>
+</context>
+<context>
+    <name>SystemNotification</name>
+    <message>
+        <location filename="../src/utils/systemnotification.cpp" line="28"/>
+        <source>Flameshot Info</source>
+        <translation>Flameshot 消息</translation>
     </message>
 </context>
 <context>

--- a/translations/Internationalization_zh_CN.ts
+++ b/translations/Internationalization_zh_CN.ts
@@ -58,7 +58,7 @@
     <message>
         <location filename="../src/tools/arrow/arrowtool.cpp" line="88"/>
         <source>Sets the Arrow as the paint tool</source>
-        <translation>选择箭头作为油漆工具</translation>
+        <translation>选择箭头作为绘画工具</translation>
     </message>
 </context>
 <context>
@@ -82,10 +82,10 @@
 Press Enter to capture the screen.
 Press Right Click to show the color picker.
 Use the Mouse Wheel to change the thickness of your tool.</source>
-        <translation>用鼠标选择一个区域,或按Esc退出。
-按Enter键捕捉屏幕。
-按鼠标右键显示颜色选择器。
-使用鼠标滚轮来改变油漆工具的厚度。</translation>
+        <translation>用鼠标选择一个区域,或按 Esc 退出。
+按 Enter 键捕捉屏幕。
+按住鼠标右键显示颜色选择器。
+使用鼠标滚轮来改变绘画工具的宽度。</translation>
     </message>
     <message>
         <location filename="../src/widgets/capture/capturewidget.cpp" line="79"/>
@@ -171,7 +171,7 @@ Use the Mouse Wheel to change the thickness of your tool.</source>
     <message>
         <location filename="../src/utils/dbusutils.cpp" line="35"/>
         <source>Unable to connect via DBus</source>
-        <translation>无法通过DBus进行连接</translation>
+        <translation>无法通过 DBus 进行连接</translation>
     </message>
 </context>
 <context>
@@ -294,13 +294,13 @@ Use the Mouse Wheel to change the thickness of your tool.</source>
     <message>
         <location filename="../src/config/geneneralconf.cpp" line="85"/>
         <source>Unable to read file.</source>
-        <translation>无法读取文件.</translation>
+        <translation>无法读取文件。</translation>
     </message>
     <message>
         <location filename="../src/config/geneneralconf.cpp" line="93"/>
         <location filename="../src/config/geneneralconf.cpp" line="109"/>
         <source>Unable to write file.</source>
-        <translation>无法写入文件.</translation>
+        <translation>无法写入文件。</translation>
     </message>
     <message>
         <location filename="../src/config/geneneralconf.cpp" line="101"/>
@@ -776,7 +776,7 @@ Use the Mouse Wheel to change the thickness of your tool.</source>
     <message>
         <location filename="../src/config/uicoloreditor.cpp" line="30"/>
         <source>UI Color Editor</source>
-        <translation>UI颜色编辑器</translation>
+        <translation>UI 颜色编辑器</translation>
     </message>
     <message>
         <location filename="../src/config/uicoloreditor.cpp" line="93"/>

--- a/translations/Internationalization_zh_TW.ts
+++ b/translations/Internationalization_zh_TW.ts
@@ -77,7 +77,7 @@
 <context>
     <name>CaptureWidget</name>
     <message>
-        <location filename="../src/widgets/capture/capturewidget.cpp" line="221"/>
+        <location filename="../src/widgets/capture/capturewidget.cpp" line="215"/>
         <source>Select an area with the mouse, or press Esc to exit.
 Press Enter to capture the screen.
 Press Right Click to show the color picker.
@@ -88,7 +88,7 @@ Use the Mouse Wheel to change the thickness of your tool.</source>
 使用滑鼠滾輪來改變繪製工具的寬度</translation>
     </message>
     <message>
-        <location filename="../src/widgets/capture/capturewidget.cpp" line="97"/>
+        <location filename="../src/widgets/capture/capturewidget.cpp" line="79"/>
         <source>Unable to capture screen</source>
         <translation>無法擷取螢幕</translation>
     </message>
@@ -132,17 +132,22 @@ Use the Mouse Wheel to change the thickness of your tool.</source>
 <context>
     <name>Controller</name>
     <message>
-        <location filename="../src/core/controller.cpp" line="108"/>
+        <location filename="../src/core/controller.cpp" line="109"/>
+        <source>&amp;Take Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/controller.cpp" line="114"/>
         <source>&amp;Configuration</source>
         <translation>&amp;設定</translation>
     </message>
     <message>
-        <location filename="../src/core/controller.cpp" line="111"/>
+        <location filename="../src/core/controller.cpp" line="117"/>
         <source>&amp;Information</source>
         <translation>&amp;資訊</translation>
     </message>
     <message>
-        <location filename="../src/core/controller.cpp" line="114"/>
+        <location filename="../src/core/controller.cpp" line="120"/>
         <source>&amp;Quit</source>
         <translation>&amp;結束</translation>
     </message>
@@ -239,7 +244,7 @@ Use the Mouse Wheel to change the thickness of your tool.</source>
 <context>
     <name>FlameshotDBusAdapter</name>
     <message>
-        <location filename="../src/core/flameshotdbusadapter.cpp" line="74"/>
+        <location filename="../src/core/flameshotdbusadapter.cpp" line="57"/>
         <source>Unable to capture screen</source>
         <translation>無法擷取螢幕</translation>
     </message>
@@ -534,6 +539,19 @@ Use the Mouse Wheel to change the thickness of your tool.</source>
     </message>
 </context>
 <context>
+    <name>PinTool</name>
+    <message>
+        <location filename="../src/tools/pin/pintool.cpp" line="34"/>
+        <source>Pin Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/pin/pintool.cpp" line="42"/>
+        <source>Pin image on the desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
     <message>
         <location filename="../src/utils/screenshotsaver.cpp" line="75"/>
@@ -559,8 +577,9 @@ Use the Mouse Wheel to change the thickness of your tool.</source>
     </message>
     <message>
         <location filename="../src/main.cpp" line="71"/>
-        <location filename="../src/main.cpp" line="304"/>
-        <location filename="../src/main.cpp" line="333"/>
+        <location filename="../src/main.cpp" line="302"/>
+        <location filename="../src/main.cpp" line="326"/>
+        <location filename="../src/main.cpp" line="355"/>
         <source>Unable to connect via DBus</source>
         <translation>無法透過 DBus 進行連接</translation>
     </message>
@@ -741,6 +760,14 @@ Use the Mouse Wheel to change the thickness of your tool.</source>
         <location filename="../src/config/strftimechooserwidget.cpp" line="67"/>
         <source>Full Date (%Y-%m-%d)</source>
         <translation>日期 (%Y-%m-%d)</translation>
+    </message>
+</context>
+<context>
+    <name>SystemNotification</name>
+    <message>
+        <location filename="../src/utils/systemnotification.cpp" line="28"/>
+        <source>Flameshot Info</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
I received users' reports about mistakes in `zh_CN` translation (translated "paint" literally as paint(noun), etc). This pull request would refresh ts files and fix mistakes in `zh_CN` translation.