### PR TITLE
Add delete Imgur image button

### DIFF
--- a/src/tools/imgur/imguruploader.cpp
+++ b/src/tools/imgur/imguruploader.cpp
@@ -74,6 +74,8 @@ void ImgurUploader::handleReply(QNetworkReply *reply) {
         QJsonObject json = response.object();
         QJsonObject data = json["data"].toObject();
         m_imageURL.setUrl(data["link"].toString());
+        m_deleteImageURL.setUrl(QString("https://imgur.com/delete/%1").arg(
+                                    data["deletehash"].toString()));
         onUploadOk();
     } else {
         m_infoLabel->setText(reply->errorString());
@@ -130,15 +132,19 @@ void ImgurUploader::onUploadOk() {
 
     m_copyUrlButton = new QPushButton(tr("Copy URL"));
     m_openUrlButton = new QPushButton(tr("Open URL"));
+    m_openDeleteUrlButton = new QPushButton(tr("Delete image"));
     m_toClipboardButton = new QPushButton(tr("Image to Clipboard."));
     m_hLayout->addWidget(m_copyUrlButton);
     m_hLayout->addWidget(m_openUrlButton);
+    m_hLayout->addWidget(m_openDeleteUrlButton);
     m_hLayout->addWidget(m_toClipboardButton);
 
     connect(m_copyUrlButton, &QPushButton::clicked,
             this, &ImgurUploader::copyURL);
     connect(m_openUrlButton, &QPushButton::clicked,
             this, &ImgurUploader::openURL);
+    connect(m_openDeleteUrlButton, &QPushButton::clicked,
+            this, &ImgurUploader::openDeleteURL);
     connect(m_toClipboardButton, &QPushButton::clicked,
             this, &ImgurUploader::copyImage);
 
@@ -154,6 +160,14 @@ void ImgurUploader::openURL() {
 void ImgurUploader::copyURL() {
     QApplication::clipboard()->setText(m_imageURL.toString());
     m_notification->showMessage(tr("URL copied to clipboard."));
+}
+
+void ImgurUploader::openDeleteURL()
+{
+    bool successful = QDesktopServices::openUrl(m_deleteImageURL);
+    if (!successful) {
+        m_notification->showMessage(tr("Unable to open the URL."));
+    }
 }
 
 void ImgurUploader::copyImage() {

--- a/src/tools/imgur/imguruploader.h
+++ b/src/tools/imgur/imguruploader.h
@@ -41,6 +41,7 @@ private slots:
 
     void openURL();
     void copyURL();
+    void openDeleteURL();
     void copyImage();
 
 private:
@@ -54,9 +55,11 @@ private:
     LoadSpinner *m_spinner;
     // uploaded
     QPushButton *m_openUrlButton;
+    QPushButton *m_openDeleteUrlButton;
     QPushButton *m_copyUrlButton;
     QPushButton *m_toClipboardButton;
     QUrl m_imageURL;
+    QUrl m_deleteImageURL;
     NotificationWidget *m_notification;
 
     void upload();


### PR DESCRIPTION
This would allow the user to delete the uploaded image.

The auto generated `deletehash` is unique for each image and and can't be guessed, just like the Image `id`.

Fixes #180