### PR TITLE
debian: Update deb packaging instructions

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-flameshot (0.4-1) xenial; urgency=medium
+flameshot (0.6~dev-1) unstable; urgency=medium
 
-  * Initial package release
+  * Initial deb package.
 
- -- Juanma Navarro Mañez <juanma1980@gmail.com>  Thu, 21 Sep 2017 09:01:13 +0200
+ -- Boyuan Yang <073plan@gmail.com>  Mon, 07 May 2018 17:34:56 +0800

--- a/debian/control
+++ b/debian/control
@@ -1,15 +1,29 @@
 Source: flameshot
-Section: admin
+Section: graphics
 Priority: optional
 Maintainer: Juanma Navarro Mañez <juanma1980@gmail.com>
-Build-Depends: debhelper (>=9), qt5-qmake, qt5-default, qttools5-dev-tools
-Standards-Version: 3.9.6
+Uploaders:
+ Boyuan Yang <073plan@gmail.com>,
+Build-Depends:
+ debhelper (>= 9),
+ qt5-qmake,
+ qtbase5-dev,
+ qttools5-dev-tools,
+Standards-Version: 4.1.4
 Homepage: https://github.com/lupoDharkael/flameshot
-Vcs-Browser: https://github.com/lupoDharkael/flameshot.git
+Vcs-Browser: https://github.com/lupoDharkael/flameshot
+Vcs-Git: https://github.com/lupoDharkael/flameshot.git
 
 Package: flameshot
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libqt5dbus5, libqt5network5, libqt5core5a, libqt5widgets5, libqt5gui5
-Suggests: openssl, ca-certificates
-Description: screenshot software
- Powerful yet simple to use screenshot software for GNU/Linux 
+Depends:
+ ${shlibs:Depends},
+ ${misc:Depends},
+Suggests:
+ ca-certificates,
+ openssl,
+Description: Powerful yet simple-to-use screenshot software
+ Flameshot is a powerful yet simple-to-use screenshot software.
+ Notable features include customizable appearance, in-app screenshot editing,
+ D-Bus interface, experimental GNOME/KDE Wayland support, integration with
+ Imgur and support for both GUI and CLI interface.

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,16 +1,365 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: flameshot
-Source: <url://example.com>
+Source: https://github.com/lupoDharkael/flameshot/
 
 Files: *
-Copyright: 2016 lupoDharkael
-License: GPL-3.0+
+Copyright: 2016-2017 lupoDharkael <izhe@hotmail.es>
+License: GPL-3+
+Comments:
+ The author copied a few lines of code from KSnapshot regiongrabber.cpp
+ revision 796531 (LGPL).
 
 Files: debian/*
 Copyright: 2017 Juanma Navarro Mañez <juanma1980@gmail.com>
-License: GPL-3.0+
+           2018 Boyuan Yang <073plan@gmail.com>
+License: GPL-3+
 
-License: GPL-3.0+
+Files: img/flameshot.*
+Copyright: 2017 lupoDharkael <izhe@hotmail.es>
+License: Free-Art-License-1.3
+
+Files: img/buttonIconsBlack/* img/buttonIconsWhite/*
+Copyright: Google Inc.
+License: Apache-2.0
+
+Files: src/widgets/capture/capturewidget.*
+Copyright: 2017 Alejandro Sirgo Rica
+           2017 Christian Kaiser <info@ckaiser.com.ar>
+           2007 Luca Gugelmann <lucag@student.ethz.ch>
+License: GPL-3+
+Comments:
+ Relicensed under GPL-3+ under flameshot project.
+ .
+ Originally based on Lightscreen areadialog.h,
+ Copyright 2017  Christian Kaiser <info@ckaiser.com.ar>
+ released under the GNU GPL2  <https://www.gnu.org/licenses/gpl-2.0.txt>
+ .
+ Originally based on KDE's KSnapshot regiongrabber.cpp, revision 796531,
+ Copyright 2007 Luca Gugelmann <lucag@student.ethz.ch>
+ released under the GNU LGPL  <http://www.gnu.org/licenses/old-licenses/library.txt>
+
+Files: src/third-party/singleapplication/*
+Copyright: 2015 - 2016 Itay Grudev
+License: Expat
+
+Files: src/third-party/Qt-Color-Widgets/*
+Copyright: 2013-2017 Mattia Basaglia <mattia.basaglia@gmail.com>
+License: LGPL-3+
+Comments:
+ As a special exception, this library can be included in any project under the
+ terms of any of the GNU licenses, distributing the whole project under a
+ different GNU license, see LICENSE-EXCEPTION for details.
+ .
+ Linking this library statically or dynamically with other modules is making a
+ combined work based on this library. Thus, the terms and conditions of the
+ GNU Lesser General Public License version 3 cover the whole combination.
+ .
+ As a special exception, the copyright holders of this library give you
+ permission to combine this library with independent
+ modules to produce an executable, and to copy and distribute the resulting
+ executable under terms of any of the GNU General Public licenses, as published
+ by the Free Software Foundation, provided that you also meet,
+ for each linked independent module, the terms and conditions of the license of
+ that module. An independent module is a module which is not derived from or
+ based on this library. If you modify this library, you may extend this
+ exception to your version of the library, but you are not obliged to do so.
+ If you do not wish to do so, delete this exception statement from your version.
+
+License: LGPL-3+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Lesser Public License as published
+ by the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ .
+ This package is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Lesser General Public License for more details.
+ .
+ You should have received a copy of the GNU General Lesser Public License
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
+ .
+ On Debian systems, the complete text of the GNU Lesser General Public
+ License version 3 can be found in "/usr/share/common-licenses/LGPL-3".
+
+License: Expat
+ The MIT License (MIT)
+ .
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ .
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+
+License: Apache-2.0
+ Google Material Design Icons are licensed under Apache License 2.0.
+ .
+ On Debian systems, the complete text of Apache License 2.0 can be
+ found in "/usr/share/common-licenses/Apache-2.0".
+
+License: Free-Art-License-1.3
+ Free Art License 1.3 (FAL 1.3)
+ .
+ Preamble
+ .
+ The Free Art License grants the right to freely copy, distribute, and
+ transform creative works without infringing the author's rights.
+ .
+ The Free Art License recognizes and protects these rights. Their
+ implementation has been reformulated in order to allow everyone to use
+ creations of the human mind in a creative manner, regardless of their
+ types and ways of expression.
+ .
+ While the public's access to creations of the human mind usually is
+ restricted by the implementation of copyright law, it is favoured by
+ the Free Art License. This license intends to allow the use of a
+ work’s resources; to establish new conditions for creating in order to
+ increase creation opportunities. The Free Art License grants the right
+ to use a work, and acknowledges the right holder’s and the user’s
+ rights and responsibility.
+ .
+ The invention and development of digital technologies, Internet and
+ Free Software have changed creation methods: creations of the human
+ mind can obviously be distributed, exchanged, and transformed. They
+ allow to produce common works to which everyone can contribute to the
+ benefit of all.
+ .
+ The main rationale for this Free Art License is to promote and protect
+ these creations of the human mind according to the principles of
+ copyleft: freedom to use, copy, distribute, transform, and prohibition
+ of exclusive appropriation.
+ .
+ Definitions
+ .
+ “work” either means the initial work, the subsequent works or the
+ common work as defined hereafter:
+ .
+ “common work” means a work composed of the initial work and all
+ subsequent contributions to it (originals and copies). The initial
+ author is the one who, by choosing this license, defines the
+ conditions under which contributions are made.
+ .
+ “Initial work” means the work created by the initiator of the common
+ work (as defined above), the copies of which can be modified by
+ whoever wants to
+ .
+ “Subsequent works” means the contributions made by authors who
+ participate in the evolution of the common work by exercising the
+ rights to reproduce, distribute, and modify that are granted by the
+ license.
+ .
+ “Originals” (sources or resources of the work) means all copies of
+ either the initial work or any subsequent work mentioning a date and
+ used by their author(s) as references for any subsequent updates,
+ interpretations, copies or reproductions.
+ .
+ “Copy” means any reproduction of an original as defined by this
+ license.
+ .
+ 1. OBJECT
+ .
+ The aim of this license is to define the conditions under which one
+ can use this work freely.
+ .
+ 2. SCOPE
+ .
+ This work is subject to copyright law. Through this license its author
+ specifies the extent to which you can copy, distribute, and modify it.
+ .
+ 2.1 FREEDOM TO COPY (OR TO MAKE REPRODUCTIONS)
+ .
+ You have the right to copy this work for yourself, your friends or any
+ other person, whatever the technique used.
+ .
+ 2.2 FREEDOM TO DISTRIBUTE, TO PERFORM IN PUBLIC
+ .
+ You have the right to distribute copies of this work; whether modified
+ or not, whatever the medium and the place, with or without any charge,
+ provided that you: attach this license without any modification to the
+ copies of this work or indicate precisely where the license can be
+ found, specify to the recipient the names of the author(s) of the
+ originals, including yours if you have modified the work, specify to
+ the recipient where to access the originals (either initial or
+ subsequent).
+ .
+ The authors of the originals may, if they wish to, give you the right
+ to distribute the originals under the same conditions as the copies.
+ .
+ 2.3 FREEDOM TO MODIFY
+ .
+ You have the right to modify copies of the originals (whether initial
+ or subsequent) provided you comply with the following conditions: all
+ conditions in article 2.2 above, if you distribute modified copies;
+ indicate that the work has been modified and, if it is possible, what
+ kind of modifications have been made; distribute the subsequent work
+ under the same license or any compatible license.
+ .
+ The author(s) of the original work may give you the right to modify it
+ under the same conditions as the copies.
+ .
+ 3. RELATED RIGHTS
+ .
+ Activities giving rise to author’s rights and related rights shall not
+ challenge the rights granted by this license.
+ .
+ For example, this is the reason why performances must be subject to
+ the same license or a compatible license. Similarly, integrating the
+ work in a database, a compilation or an anthology shall not prevent
+ anyone from using the work under the same conditions as those defined
+ in this license.
+ .
+ 4. INCORPORATION OF THE WORK
+ .
+ Incorporating this work into a larger work that is not subject to the
+ Free Art License shall not challenge the rights granted by this
+ license.
+ .
+ If the work can no longer be accessed apart from the larger work in
+ which it is incorporated, then incorporation shall only be allowed
+ under the condition that the larger work is subject either to the Free
+ Art License or a compatible license.
+ .
+ 5. COMPATIBILITY
+ .
+ A license is compatible with the Free Art License provided: it gives
+ the right to copy, distribute, and modify copies of the work including
+ for commercial purposes and without any other restrictions than those
+ required by the respect of the other compatibility criteria; it
+ ensures proper attribution of the work to its authors and access to
+ previous versions of the work when possible; it recognizes the Free
+ Art License as compatible (reciprocity); it requires that changes made
+ to the work be subject to the same license or to a license which also
+ meets these compatibility criteria.
+ .
+ 6. YOUR INTELLECTUAL RIGHTS
+ .
+ This license does not aim at denying your author's rights in your
+ contribution or any related right. By choosing to contribute to the
+ development of this common work, you only agree to grant others the
+ same rights with regard to your contribution as those you were granted
+ by this license. Conferring these rights does not mean you have to
+ give up your intellectual rights.
+ .
+ 7. YOUR RESPONSIBILITIES
+ .
+ The freedom to use the work as defined by the Free Art License (right
+ to copy, distribute, modify) implies that everyone is responsible for
+ their own actions.
+ .
+ 8. DURATION OF THE LICENSE
+ .
+ This license takes effect as of your acceptance of its terms. The act
+ of copying, distributing, or modifying the work constitutes a tacit
+ agreement. This license will remain in effect for as long as the
+ copyright which is attached to the work. If you do not respect the
+ terms of this license, you automatically lose the rights that it
+ confers.
+ .
+ If the legal status or legislation to which you are subject makes it
+ impossible for you to respect the terms of this license, you may not
+ make use of the rights which it confers.
+ .
+ 9. VARIOUS VERSIONS OF THE LICENSE
+ .
+ This license may undergo periodic modifications to incorporate
+ improvements by its authors (instigators of the “Copyleft Attitude”
+ movement) by way of new, numbered versions.
+ .
+ You will always have the choice of accepting the terms contained in
+ the version under which the copy of the work was distributed to you,
+ or alternatively, to use the provisions of one of the subsequent
+ versions.
+ .
+ 10. SUB-LICENSING
+ .
+ Sub-licenses are not authorized by this license. Any person wishing to
+ make use of the rights that it confers will be directly bound to the
+ authors of the common work.
+ .
+ 11. LEGAL FRAMEWORK
+ .
+ This license is written with respect to both French law and the Berne
+ Convention for the Protection of Literary and Artistic Works.
+ .
+ USER GUIDE
+ .
+ - How to use the Free Art License?
+ .
+ To benefit from the Free Art License, you only need to mention the
+ following elements on your work:
+ .
+   [Name of the author, title, date of the work. When applicable, names
+   of authors of the common work and, if possible, where to find the
+   originals].
+ .
+ Copyleft: This is a free work, you can copy, distribute, and modify it
+ under the terms of the Free Art License
+ http://artlibre.org/licence/lal/en/
+ .
+ - Why to use the Free Art License?
+ .
+   1.To give the greatest number of people access to your work.
+ .
+   2.To allow it to be distributed freely.
+ .
+   3.To allow it to evolve by allowing its copy, distribution, and
+     transformation by others.
+ .
+   4.So that you benefit from the resources of a work when it is under
+     the Free Art License: to be able to copy, distribute or transform
+     it freely.
+ .
+   5.But also, because the Free Art License offers a legal framework to
+     disallow any misappropriation. It is forbidden to take hold of
+     your work and bypass the creative process for one's exclusive
+     possession.
+ .
+ .
+ - When to use the Free Art License?
+ .
+ Any time you want to benefit and make others benefit from the right to
+ copy, distribute and transform creative works without any exclusive
+ appropriation, you should use the Free Art License. You can for
+ example use it for scientific, artistic or educational projects.
+ .
+ - What kinds of works can be subject to the Free Art License?
+ .
+ The Free Art License can be applied to digital as well as physical
+ works.  You can choose to apply the Free Art License on any text,
+ picture, sound, gesture, or whatever sort of stuff on which you have
+ sufficient author's rights.
+ .
+ - Historical background of this license:
+ .
+ It is the result of observing, using and creating digital
+ technologies, free software, the Internet and art. It arose from the
+ “Copyleft Attitude” meetings which took place in Paris in 2000. For
+ the first time, these meetings brought together members of the Free
+ Software community, artists, and members of the art world. The goal
+ was to adapt the principles of Copyleft and free software to all sorts
+ of creations. http://www.artlibre.org
+ .
+ Copyleft Attitude, 2007.
+ .
+ You can make reproductions and distribute this license verbatim
+ (without any changes).
+ .
+     Translation : Jonathan Clarke, Benjamin Jean, Griselda Jung, Fanny
+     Mourguet, Antoine Pitrou.  Thanks to framalang.org 
+ 
+License: GPL-3+
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or

--- a/debian/docs
+++ b/debian/docs
@@ -1,0 +1,1 @@
+README.md

--- a/debian/rules
+++ b/debian/rules
@@ -13,6 +13,7 @@
 # package maintainers to append LDFLAGS
 #export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
 
+export QT_SELECT := 5
 
 %:
 	dh $@ 


### PR DESCRIPTION
With this commit, I would expect users able to build deb packages with a cleaner packaging instruction that is compatible from down to Ubuntu 16.04.x LTS.