### PR TITLE
Fix Export configuration button

### DIFF
--- a/src/config/geneneralconf.cpp
+++ b/src/config/geneneralconf.cpp
@@ -100,6 +100,12 @@ void GeneneralConf::importConfiguration() {
 void GeneneralConf::exportFileConfiguration() {
     QString fileName = QFileDialog::getSaveFileName(this, tr("Save File"),
                                "flameshot.conf");
+
+    // Cancel button
+    if (fileName.isNull()) {
+        return;
+    }
+
     QFile targetFile(fileName);
     if (targetFile.exists()) {
         targetFile.remove();


### PR DESCRIPTION
If the user presses the Cancel button using the `QFileDialog::getSaveFileName()` modal file dialog, it will return `null` string.

Adding this condition will prevent to show an error when trying to write to disk using an invalid filename.