### PR TITLE
Set dynamically Imgur client ID

### DIFF
--- a/flameshot.pro
+++ b/flameshot.pro
@@ -248,13 +248,13 @@ unix:!macx {
 
     dbus.path = $${BASEDIR}$${PREFIX}/share/dbus-1/interfaces/
     dbus.files = dbus/org.dharkael.Flameshot.xml
-    
+
     icon.path = $${BASEDIR}$${PREFIX}/share/icons/
     icon.files = img/flameshot.png
 
     completion.path = $${BASEDIR}$${PREFIX}/share/bash-completion/completions/
     completion.files = docs/bash-completion/flameshot
-    
+
     appdata.path = $${BASEDIR}$${PREFIX}/share/metainfo/
     appdata.files = docs/appdata/flameshot.appdata.xml
 
@@ -279,3 +279,5 @@ unix:!macx {
         appdata
 }
 
+# Imgur API data
+include(src/imgur.pri)

--- a/src/imgur.pri
+++ b/src/imgur.pri
@@ -1,0 +1,7 @@
+# Use default Imgur client_id if user did not pass
+# this variable to qmake
+isEmpty(IMGUR_CLIENT_ID) {
+    IMGUR_CLIENT_ID = "313baf0c7b4d3ff"
+}
+
+DEFINES += IMGUR_CLIENT_ID=\\\"$${IMGUR_CLIENT_ID}\\\"

--- a/src/tools/imgur/imguruploader.cpp
+++ b/src/tools/imgur/imguruploader.cpp
@@ -110,7 +110,7 @@ void ImgurUploader::upload() {
     QNetworkRequest request(url);
     request.setHeader(QNetworkRequest::ContentTypeHeader,
                       "application/application/x-www-form-urlencoded");
-    request.setRawHeader("Authorization", "Client-ID 313baf0c7b4d3ff");
+    request.setRawHeader("Authorization", QString("Client-ID %1").arg(IMGUR_CLIENT_ID).toUtf8());
 
     m_NetworkAM->post(request, byteArray);
 }
@@ -147,7 +147,6 @@ void ImgurUploader::onUploadOk() {
             this, &ImgurUploader::openDeleteURL);
     connect(m_toClipboardButton, &QPushButton::clicked,
             this, &ImgurUploader::copyImage);
-
 }
 
 void ImgurUploader::openURL() {
@@ -174,4 +173,3 @@ void ImgurUploader::copyImage() {
     QApplication::clipboard()->setPixmap(m_pixmap);
     m_notification->showMessage(tr("Screenshot copied to clipboard."));
 }
-


### PR DESCRIPTION
This will allow users to set their own Imgur `client_id` passing the `IMGUR_CLIENT_ID` variable to `qmake`.

If the users does not set this variable, it will fallback to the default value.

P.S.: This will create a new project file (`src/imgur.pri`) to avoid pollution of the main project file and to keep data specifically about Imgur.