### PR TITLE
Support BSDs OSs

### DIFF
--- a/src/config/geneneralconf.cpp
+++ b/src/config/geneneralconf.cpp
@@ -48,7 +48,7 @@ void GeneneralConf::updateComponents() {
     m_sysNotifications->setChecked(config.desktopNotificationValue());
     m_autostart->setChecked(config.startupLaunchValue());
 
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
     m_showTray->setChecked(!config.disabledTrayIconValue());
 #endif
 }
@@ -155,7 +155,7 @@ void GeneneralConf::initShowDesktopNotification() {
 }
 
 void GeneneralConf::initShowTrayIcon() {
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
     m_showTray = new QCheckBox(tr("Show tray icon"), this);
     ConfigHandler config;
     bool checked = !config.disabledTrayIconValue();

--- a/src/core/controller.cpp
+++ b/src/core/controller.cpp
@@ -41,7 +41,7 @@ Controller::Controller() : m_captureWindow(nullptr) {
     qApp->setQuitOnLastWindowClosed(false);
 
     // init tray icon
-#if defined(Q_OS_LINUX)
+#if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
     if (!ConfigHandler().disabledTrayIconValue()) {
         enableTrayIcon();
     }
@@ -204,7 +204,7 @@ void Controller::enableTrayIcon() {
 }
 
 void Controller::disableTrayIcon() {
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
     if (m_trayIcon) {
         m_trayIcon->deleteLater();
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,7 +29,7 @@
 #include <QTimer>
 #include <QDir>
 
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
 #include "src/core/flameshotdbusadapter.h"
 #include "src/utils/dbusutils.h"
 #include <QDBusMessage>
@@ -64,7 +64,7 @@ int main(int argc, char *argv[]) {
         app.setOrganizationName("Dharkael");
 
         auto c = Controller::getInstance();
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
         new FlameshotDBusAdapter(c);
         QDBusConnection dbus = QDBusConnection::sessionBus();
         if (!dbus.isConnected()) {

--- a/src/tools/pin/pintool.cpp
+++ b/src/tools/pin/pintool.cpp
@@ -45,7 +45,7 @@ QString PinTool::description() const {
 QWidget* PinTool::widget() {
     PinWidget *w = new PinWidget(m_pixmap);
     const int &&m = w->margin();
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
     QRect adjusted_pos = m_geometry + QMargins(m,-m,-m,-m);
 #else
     QRect adjusted_pos = m_geometry + QMargins(m, m, m, m);

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -240,7 +240,7 @@ void ConfigHandler::setKeepOpenAppLauncher(const bool keepOpen) {
 
 bool ConfigHandler::startupLaunchValue() {
     bool res = false;
-#if defined(Q_OS_LINUX)
+#if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
     QString path = QDir::homePath() + "/.config/autostart/Flameshot.desktop";
     res = QFile(path).exists();
 #elif defined(Q_OS_WIN)
@@ -254,7 +254,7 @@ bool ConfigHandler::startupLaunchValue() {
 }
 
 void ConfigHandler::setStartupLaunch(const bool start) {
-#if defined(Q_OS_LINUX)
+#if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
     QString path = QDir::homePath() + "/.config/autostart/Flameshot.desktop";
     QFile file(path);
     if (start) {

--- a/src/utils/pathinfo.cpp
+++ b/src/utils/pathinfo.cpp
@@ -41,7 +41,7 @@ QStringList PathInfo::translationsPaths() {
     QString binaryPath = QFileInfo(qApp->applicationDirPath())
             .absoluteFilePath();
     QString trPath = QDir::toNativeSeparators(binaryPath + "/translations") ;
-#if defined(Q_OS_LINUX)
+#if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
     return QStringList()
             << QString(APP_PREFIX) + "/share/flameshot/translations"
             << trPath

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -24,7 +24,7 @@
 #include <QApplication>
 #include <QDesktopWidget>
 
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
 #include <QDBusInterface>
 #include <QDBusReply>
 #include <QDir>
@@ -36,7 +36,7 @@ ScreenGrabber::ScreenGrabber(QObject *parent) : QObject(parent) {
 
 QPixmap ScreenGrabber::grabEntireDesktop(bool &ok) {
     ok = true;
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
     if(m_info.waylandDectected()) {
         QPixmap res;
         // handle screenshot based on DE

--- a/src/utils/systemnotification.cpp
+++ b/src/utils/systemnotification.cpp
@@ -10,7 +10,7 @@
 #endif
 #include "src/core/controller.h"
 
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
 SystemNotification::SystemNotification(QObject *parent) : QObject(parent) {
     m_interface = new QDBusInterface(QStringLiteral("org.freedesktop.Notifications"),
                                      QStringLiteral("/org/freedesktop/Notifications"),


### PR DESCRIPTION
Use defined(Q_OS_LINUX) || defined(Q_OS_UNIX) where applicable to support BSD OSs.

We maintain the flameshot in the FreeBSD ports tree. The last version (0.5.1) added some checks for Linux and broke the app on FreeBSD.

