### PR TITLE
Fix typo; Refresh translation; Update zh-CN translation

### DIFF
--- a/dbus/org.dharkael.Flameshot.xml
+++ b/dbus/org.dharkael.Flameshot.xml
@@ -62,7 +62,7 @@
 
     <!--
         trayIconEnabled:
-        @enabled: The new state fot the trayIcon.
+        @enabled: The new state for the trayIcon.
 
         Enable or disable the trayIcon.
     -->
@@ -73,7 +73,7 @@
 
     <!--
         autostartEnabled:
-        @enabled: The new state fot the autostart.
+        @enabled: The new state for the autostart.
 
         Enable or disable the autostart of the program.
     -->

--- a/docs/desktopEntry/package/flameshot.desktop
+++ b/docs/desktopEntry/package/flameshot.desktop
@@ -1,5 +1,6 @@
 [Desktop Entry]
 Name=Flameshot
+Name[zh_CN]=火焰截图
 GenericName=Screenshot tool
 GenericName[zh_CN]=屏幕截图工具
 GenericName[pl]=Zrzuty ekranu

--- a/src/config/uicoloreditor.cpp
+++ b/src/config/uicoloreditor.cpp
@@ -136,7 +136,7 @@ void UIcolorEditor::initButtons() {
             this, &UIcolorEditor::changeLastButton);
     connect(m_buttonContrast, &CaptureButton::pressedButton,
             this, &UIcolorEditor::changeLastButton);
-    // clicking the labels chages the button too
+    // clicking the labels changes the button too
     connect(m_labelMain, &ClickableLabel::clicked,
             this, [this]{ changeLastButton(m_buttonMainColor); });
     connect(m_labelContrast, &ClickableLabel::clicked,

--- a/src/tools/capturetool.h
+++ b/src/tools/capturetool.h
@@ -111,7 +111,7 @@ public:
 
     // revert changes
     virtual void undo(QPixmap &pixmap) = 0;
-    // Called everytime the tool has to draw
+    // Called every time the tool has to draw
     // recordUndo indicates when the tool should save the information
     // for the undo(), if the value is false calling undo() after
     // that process should not modify revert the changes.

--- a/src/tools/redo/redotool.cpp
+++ b/src/tools/redo/redotool.cpp
@@ -39,7 +39,7 @@ QString RedoTool::nameID() {
 }
 
 QString RedoTool::description() const {
-    return "Redo the next modification";
+    return tr("Redo the next modification");
 }
 
 CaptureTool* RedoTool::copy(QObject *parent) {

--- a/src/widgets/capture/buttonhandler.cpp
+++ b/src/widgets/capture/buttonhandler.cpp
@@ -112,7 +112,7 @@ void ButtonHandler::updatePosition(const QRect &selection) {
         elemsAtCorners -= elemCornersTop;
         int elemCornersBotton = qBound(0, elemsAtCorners, maxExtra);
 
-        // Add buttons at the botton of the seletion
+        // Add buttons at the button of the seletion
         if (!m_blockedBotton) {
             int addCounter = buttonsPerRow + elemCornersBotton;
             // Don't add more than we have

--- a/translations/Internationalization_ca.ts
+++ b/translations/Internationalization_ca.ts
@@ -518,6 +518,10 @@ Press Space to open the side panel.</source>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Redo the next modification</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SaveTool</name>

--- a/translations/Internationalization_es.ts
+++ b/translations/Internationalization_es.ts
@@ -496,17 +496,17 @@ Usa la rueda del ratón para cambiar el grosor de la herramienta.</translation>
         <translation>Descripción</translation>
     </message>
     <message>
-        <location filename="../src/widgets/infowindow.cpp" line="97"/>
+        <location filename="../src/widgets/infowindow.cpp" line="107"/>
         <source>&lt;u&gt;&lt;b&gt;License&lt;/b&gt;&lt;/u&gt;</source>
         <translation>&lt;u&gt;&lt;b&gt;Licencia&lt;/b&gt;&lt;/u&gt;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/infowindow.cpp" line="105"/>
+        <location filename="../src/widgets/infowindow.cpp" line="115"/>
         <source>&lt;u&gt;&lt;b&gt;Version&lt;/b&gt;&lt;/u&gt;</source>
         <translation>&lt;u&gt;&lt;b&gt;Versión&lt;/b&gt;&lt;/u&gt;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/infowindow.cpp" line="115"/>
+        <location filename="../src/widgets/infowindow.cpp" line="125"/>
         <source>&lt;u&gt;&lt;b&gt;Shortcuts&lt;/b&gt;&lt;/u&gt;</source>
         <translation>&lt;u&gt;&lt;b&gt;Atajos&lt;/b&gt;&lt;/u&gt;</translation>
     </message>
@@ -638,6 +638,11 @@ Usa la rueda del ratón para cambiar el grosor de la herramienta.</translation>
         <location filename="../src/tools/redo/redotool.cpp" line="34"/>
         <source>Redo</source>
         <translation>Rehacer</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/redo/redotool.cpp" line="42"/>
+        <source>Redo the next modification</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/Internationalization_fr.ts
+++ b/translations/Internationalization_fr.ts
@@ -492,17 +492,17 @@ Utiliser la molette pour changer l&apos;épaisseur de l&apos;outil.</translation
         <translation>Description</translation>
     </message>
     <message>
-        <location filename="../src/widgets/infowindow.cpp" line="97"/>
+        <location filename="../src/widgets/infowindow.cpp" line="107"/>
         <source>&lt;u&gt;&lt;b&gt;License&lt;/b&gt;&lt;/u&gt;</source>
         <translation>&lt;u&gt;&lt;b&gt;Licences&lt;/b&gt;&lt;/u&gt;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/infowindow.cpp" line="105"/>
+        <location filename="../src/widgets/infowindow.cpp" line="115"/>
         <source>&lt;u&gt;&lt;b&gt;Version&lt;/b&gt;&lt;/u&gt;</source>
         <translation>&lt;u&gt;&lt;b&gt;Version&lt;/b&gt;&lt;/u&gt;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/infowindow.cpp" line="115"/>
+        <location filename="../src/widgets/infowindow.cpp" line="125"/>
         <source>&lt;u&gt;&lt;b&gt;Shortcuts&lt;/b&gt;&lt;/u&gt;</source>
         <translation>&lt;u&gt;&lt;b&gt;Raccourci&lt;/b&gt;&lt;/u&gt;</translation>
     </message>
@@ -634,6 +634,11 @@ Utiliser la molette pour changer l&apos;épaisseur de l&apos;outil.</translation
         <location filename="../src/tools/redo/redotool.cpp" line="34"/>
         <source>Redo</source>
         <translation>Rétablir</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/redo/redotool.cpp" line="42"/>
+        <source>Redo the next modification</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/Internationalization_ka.ts
+++ b/translations/Internationalization_ka.ts
@@ -492,17 +492,17 @@ Use the Mouse Wheel to change the thickness of your tool.</source>
         <translation>აღწერა</translation>
     </message>
     <message>
-        <location filename="../src/widgets/infowindow.cpp" line="97"/>
+        <location filename="../src/widgets/infowindow.cpp" line="107"/>
         <source>&lt;u&gt;&lt;b&gt;License&lt;/b&gt;&lt;/u&gt;</source>
         <translation>&lt;u&gt;&lt;b&gt;ლიცენზია&lt;/b&gt;&lt;/u&gt;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/infowindow.cpp" line="105"/>
+        <location filename="../src/widgets/infowindow.cpp" line="115"/>
         <source>&lt;u&gt;&lt;b&gt;Version&lt;/b&gt;&lt;/u&gt;</source>
         <translation>&lt;u&gt;&lt;b&gt;ვერსია&lt;/b&gt;&lt;/u&gt;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/infowindow.cpp" line="115"/>
+        <location filename="../src/widgets/infowindow.cpp" line="125"/>
         <source>&lt;u&gt;&lt;b&gt;Shortcuts&lt;/b&gt;&lt;/u&gt;</source>
         <translation>&lt;u&gt;&lt;b&gt;მალსახმობები&lt;/b&gt;&lt;/u&gt;</translation>
     </message>
@@ -633,6 +633,11 @@ Use the Mouse Wheel to change the thickness of your tool.</source>
     <message>
         <location filename="../src/tools/redo/redotool.cpp" line="34"/>
         <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/redo/redotool.cpp" line="42"/>
+        <source>Redo the next modification</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/Internationalization_pl.ts
+++ b/translations/Internationalization_pl.ts
@@ -495,17 +495,17 @@ Użyj kółka myszy, aby zmienić grubość narzędzia do rysowania.</translatio
         <translation>Działanie</translation>
     </message>
     <message>
-        <location filename="../src/widgets/infowindow.cpp" line="97"/>
+        <location filename="../src/widgets/infowindow.cpp" line="107"/>
         <source>&lt;u&gt;&lt;b&gt;License&lt;/b&gt;&lt;/u&gt;</source>
         <translation>&lt;u&gt;&lt;b&gt;Licencja&lt;/b&gt;&lt;/u&gt;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/infowindow.cpp" line="105"/>
+        <location filename="../src/widgets/infowindow.cpp" line="115"/>
         <source>&lt;u&gt;&lt;b&gt;Version&lt;/b&gt;&lt;/u&gt;</source>
         <translation>&lt;u&gt;&lt;b&gt;Wersja&lt;/b&gt;&lt;/u&gt;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/infowindow.cpp" line="115"/>
+        <location filename="../src/widgets/infowindow.cpp" line="125"/>
         <source>&lt;u&gt;&lt;b&gt;Shortcuts&lt;/b&gt;&lt;/u&gt;</source>
         <translation>&lt;u&gt;&lt;b&gt;Skróty klawiszowe&lt;/b&gt;&lt;/u&gt;</translation>
     </message>
@@ -637,6 +637,11 @@ Użyj kółka myszy, aby zmienić grubość narzędzia do rysowania.</translatio
         <location filename="../src/tools/redo/redotool.cpp" line="34"/>
         <source>Redo</source>
         <translation>Cofnij</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/redo/redotool.cpp" line="42"/>
+        <source>Redo the next modification</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/Internationalization_ru.ts
+++ b/translations/Internationalization_ru.ts
@@ -492,17 +492,17 @@ Use the Mouse Wheel to change the thickness of your tool.</source>
         <translation>Описание</translation>
     </message>
     <message>
-        <location filename="../src/widgets/infowindow.cpp" line="97"/>
+        <location filename="../src/widgets/infowindow.cpp" line="107"/>
         <source>&lt;u&gt;&lt;b&gt;License&lt;/b&gt;&lt;/u&gt;</source>
         <translation>&lt;u&gt;&lt;b&gt;Лицензия&lt;/b&gt;&lt;/u&gt;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/infowindow.cpp" line="105"/>
+        <location filename="../src/widgets/infowindow.cpp" line="115"/>
         <source>&lt;u&gt;&lt;b&gt;Version&lt;/b&gt;&lt;/u&gt;</source>
         <translation>&lt;u&gt;&lt;b&gt;Версия&lt;/b&gt;&lt;/u&gt;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/infowindow.cpp" line="115"/>
+        <location filename="../src/widgets/infowindow.cpp" line="125"/>
         <source>&lt;u&gt;&lt;b&gt;Shortcuts&lt;/b&gt;&lt;/u&gt;</source>
         <translation>&lt;u&gt;&lt;b&gt;Горячие клавиши&lt;/b&gt;&lt;/u&gt;</translation>
     </message>
@@ -633,6 +633,11 @@ Use the Mouse Wheel to change the thickness of your tool.</source>
     <message>
         <location filename="../src/tools/redo/redotool.cpp" line="34"/>
         <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/redo/redotool.cpp" line="42"/>
+        <source>Redo the next modification</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/Internationalization_tr.ts
+++ b/translations/Internationalization_tr.ts
@@ -492,17 +492,17 @@ Araç boyutunu değiştirmek için fare tekerleğini kullanın.</translation>
         <translation>Tanım</translation>
     </message>
     <message>
-        <location filename="../src/widgets/infowindow.cpp" line="97"/>
+        <location filename="../src/widgets/infowindow.cpp" line="107"/>
         <source>&lt;u&gt;&lt;b&gt;License&lt;/b&gt;&lt;/u&gt;</source>
         <translation>&lt;u&gt;&lt;b&gt;Lisans&lt;/b&gt;&lt;/u&gt;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/infowindow.cpp" line="105"/>
+        <location filename="../src/widgets/infowindow.cpp" line="115"/>
         <source>&lt;u&gt;&lt;b&gt;Version&lt;/b&gt;&lt;/u&gt;</source>
         <translation>&lt;u&gt;&lt;b&gt;Sürüm&lt;/b&gt;&lt;/u&gt;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/infowindow.cpp" line="115"/>
+        <location filename="../src/widgets/infowindow.cpp" line="125"/>
         <source>&lt;u&gt;&lt;b&gt;Shortcuts&lt;/b&gt;&lt;/u&gt;</source>
         <translation>&lt;u&gt;&lt;b&gt;Kısayollar&lt;/b&gt;&lt;/u&gt;</translation>
     </message>
@@ -634,6 +634,11 @@ Araç boyutunu değiştirmek için fare tekerleğini kullanın.</translation>
         <location filename="../src/tools/redo/redotool.cpp" line="34"/>
         <source>Redo</source>
         <translation>Yeniden</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/redo/redotool.cpp" line="42"/>
+        <source>Redo the next modification</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/Internationalization_zh_CN.ts
+++ b/translations/Internationalization_zh_CN.ts
@@ -193,7 +193,7 @@ Press Space to open the side panel.</source>
     <message>
         <location filename="../src/tools/copy/copytool.cpp" line="43"/>
         <source>Copies the selection into the clipboard</source>
-        <translation type="unfinished"></translation>
+        <translation>复制选择到剪贴板</translation>
     </message>
     <message>
         <source>Copies the selecion into the clipboard</source>
@@ -492,17 +492,17 @@ Press Space to open the side panel.</source>
         <translation>描述</translation>
     </message>
     <message>
-        <location filename="../src/widgets/infowindow.cpp" line="97"/>
+        <location filename="../src/widgets/infowindow.cpp" line="107"/>
         <source>&lt;u&gt;&lt;b&gt;License&lt;/b&gt;&lt;/u&gt;</source>
         <translation>&lt;u&gt;&lt;b&gt;许可证&lt;/b&gt;&lt;/u&gt;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/infowindow.cpp" line="105"/>
+        <location filename="../src/widgets/infowindow.cpp" line="115"/>
         <source>&lt;u&gt;&lt;b&gt;Version&lt;/b&gt;&lt;/u&gt;</source>
         <translation>&lt;u&gt;&lt;b&gt;版本&lt;/b&gt;&lt;/u&gt;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/infowindow.cpp" line="115"/>
+        <location filename="../src/widgets/infowindow.cpp" line="125"/>
         <source>&lt;u&gt;&lt;b&gt;Shortcuts&lt;/b&gt;&lt;/u&gt;</source>
         <translation>&lt;u&gt;&lt;b&gt;快捷键&lt;/b&gt;&lt;/u&gt;</translation>
     </message>
@@ -640,6 +640,11 @@ Press Space to open the side panel.</source>
         <source>Redo</source>
         <translation>重做</translation>
     </message>
+    <message>
+        <location filename="../src/tools/redo/redotool.cpp" line="42"/>
+        <source>Redo the next modification</source>
+        <translation>重做上次修改</translation>
+    </message>
 </context>
 <context>
     <name>SaveTool</name>
@@ -693,27 +698,27 @@ Press Space to open the side panel.</source>
     <message>
         <location filename="../src/config/strftimechooserwidget.cpp" line="47"/>
         <source>Century (00-99)</source>
-        <translation>世纪 (00-99)</translation>
+        <translation>世纪（00-99）</translation>
     </message>
     <message>
         <location filename="../src/config/strftimechooserwidget.cpp" line="48"/>
         <source>Year (00-99)</source>
-        <translation>年 (00-99)</translation>
+        <translation>年（00-99）</translation>
     </message>
     <message>
         <location filename="../src/config/strftimechooserwidget.cpp" line="49"/>
         <source>Year (2000)</source>
-        <translation>年 (2000)</translation>
+        <translation>年（2000）</translation>
     </message>
     <message>
         <location filename="../src/config/strftimechooserwidget.cpp" line="50"/>
         <source>Month Name (jan)</source>
-        <translation>月 (jul)</translation>
+        <translation>月（1月 - 12月）</translation>
     </message>
     <message>
         <location filename="../src/config/strftimechooserwidget.cpp" line="51"/>
         <source>Month Name (january)</source>
-        <translation>月 (juliol)</translation>
+        <translation>月（一月 - 十二月）</translation>
     </message>
     <message>
         <location filename="../src/config/strftimechooserwidget.cpp" line="52"/>
@@ -723,77 +728,77 @@ Press Space to open the side panel.</source>
     <message>
         <location filename="../src/config/strftimechooserwidget.cpp" line="53"/>
         <source>Week Day (1-7)</source>
-        <translation>平常日 (1-7)</translation>
+        <translation>周内的日（1-7）</translation>
     </message>
     <message>
         <location filename="../src/config/strftimechooserwidget.cpp" line="54"/>
         <source>Week (01-53)</source>
-        <translation>周 (01-53)</translation>
+        <translation>周（01-53）</translation>
     </message>
     <message>
         <location filename="../src/config/strftimechooserwidget.cpp" line="55"/>
         <source>Day Name (mon)</source>
-        <translation>星期 (dg)</translation>
+        <translation>星期（一 - 七）</translation>
     </message>
     <message>
         <location filename="../src/config/strftimechooserwidget.cpp" line="56"/>
         <source>Day Name (monday)</source>
-        <translation>星期 (diumenge)</translation>
+        <translation>星期（星期一 - 星期日）</translation>
     </message>
     <message>
         <location filename="../src/config/strftimechooserwidget.cpp" line="57"/>
         <source>Day (01-31)</source>
-        <translation>天 (01-31)</translation>
+        <translation>天（01-31）</translation>
     </message>
     <message>
         <location filename="../src/config/strftimechooserwidget.cpp" line="58"/>
         <source>Day of Month (1-31)</source>
-        <translation>一月中的某天 (1-31)</translation>
+        <translation>一月中的某天（1-31）</translation>
     </message>
     <message>
         <location filename="../src/config/strftimechooserwidget.cpp" line="59"/>
         <source>Day (001-366)</source>
-        <translation>天 (001-366)</translation>
+        <translation>天（001-366）</translation>
     </message>
     <message>
         <location filename="../src/config/strftimechooserwidget.cpp" line="60"/>
         <source>Time (%H-%M-%S)</source>
-        <translation>时间 (%H-%M-%S)</translation>
+        <translation>时间（%H-%M-%S）</translation>
     </message>
     <message>
         <location filename="../src/config/strftimechooserwidget.cpp" line="61"/>
         <source>Time (%H-%M)</source>
-        <translation>时间 (%H-%M)</translation>
+        <translation>时间（%H-%M）</translation>
     </message>
     <message>
         <location filename="../src/config/strftimechooserwidget.cpp" line="62"/>
         <source>Hour (00-23)</source>
-        <translation>小时 (00-23)</translation>
+        <translation>小时（00-23）</translation>
     </message>
     <message>
         <location filename="../src/config/strftimechooserwidget.cpp" line="63"/>
         <source>Hour (01-12)</source>
-        <translation>小时 (01-12)</translation>
+        <translation>小时（01-12）</translation>
     </message>
     <message>
         <location filename="../src/config/strftimechooserwidget.cpp" line="64"/>
         <source>Minute (00-59)</source>
-        <translation>分钟 (00-59)</translation>
+        <translation>分钟（00-59）</translation>
     </message>
     <message>
         <location filename="../src/config/strftimechooserwidget.cpp" line="65"/>
         <source>Second (00-59)</source>
-        <translation>秒 (00-59)</translation>
+        <translation>秒（00-59）</translation>
     </message>
     <message>
         <location filename="../src/config/strftimechooserwidget.cpp" line="66"/>
         <source>Full Date (%m/%d/%y)</source>
-        <translation>日期 (%m/%d/%y)</translation>
+        <translation>完整日期（%m/%d/%y）</translation>
     </message>
     <message>
         <location filename="../src/config/strftimechooserwidget.cpp" line="67"/>
         <source>Full Date (%Y-%m-%d)</source>
-        <translation>日期 (%Y-%m-%d)</translation>
+        <translation>完整日期（%Y-%m-%d）</translation>
     </message>
 </context>
 <context>
@@ -845,7 +850,7 @@ Press Space to open the side panel.</source>
     <message>
         <location filename="../src/config/uicoloreditor.cpp" line="30"/>
         <source>UI Color Editor</source>
-        <translation>UI 颜色编辑器</translation>
+        <translation>用户界面颜色编辑器</translation>
     </message>
     <message>
         <location filename="../src/config/uicoloreditor.cpp" line="93"/>

--- a/translations/Internationalization_zh_TW.ts
+++ b/translations/Internationalization_zh_TW.ts
@@ -487,17 +487,17 @@ Press Space to open the side panel.</source>
         <translation>描述</translation>
     </message>
     <message>
-        <location filename="../src/widgets/infowindow.cpp" line="97"/>
+        <location filename="../src/widgets/infowindow.cpp" line="107"/>
         <source>&lt;u&gt;&lt;b&gt;License&lt;/b&gt;&lt;/u&gt;</source>
         <translation>&lt;u&gt;&lt;b&gt;授權條款&lt;/b&gt;&lt;/u&gt;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/infowindow.cpp" line="105"/>
+        <location filename="../src/widgets/infowindow.cpp" line="115"/>
         <source>&lt;u&gt;&lt;b&gt;Version&lt;/b&gt;&lt;/u&gt;</source>
         <translation>&lt;u&gt;&lt;b&gt;版本&lt;/b&gt;&lt;/u&gt;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/infowindow.cpp" line="115"/>
+        <location filename="../src/widgets/infowindow.cpp" line="125"/>
         <source>&lt;u&gt;&lt;b&gt;Shortcuts&lt;/b&gt;&lt;/u&gt;</source>
         <translation>&lt;u&gt;&lt;b&gt;快速鍵&lt;/b&gt;&lt;/u&gt;</translation>
     </message>
@@ -633,6 +633,11 @@ Press Space to open the side panel.</source>
     <message>
         <location filename="../src/tools/redo/redotool.cpp" line="34"/>
         <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/redo/redotool.cpp" line="42"/>
+        <source>Redo the next modification</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
* Fix typos found by codespell
* Fix a problem that redotool description is not marked as translatable
* Refresh translations using `lupdate`; Update `zh_CN` translation