### PR TITLE
Update Spanish translation and cleanup

### DIFF
--- a/src/tools/text/texttool.h
+++ b/src/tools/text/texttool.h
@@ -24,6 +24,7 @@ class TextWidget;
 class TextConfig;
 
 class TextTool : public CaptureTool {
+    Q_OBJECT
 public:
     explicit TextTool(QObject *parent = nullptr);
 

--- a/translations/Internationalization_ca.ts
+++ b/translations/Internationalization_ca.ts
@@ -64,16 +64,6 @@
 <context>
     <name>CaptureWidget</name>
     <message>
-        <source>Select an area with the mouse, or press Esc to exit.
-Press Enter to capture the screen.
-Press Right Click to show the color picker.
-Use the Mouse Wheel to change the thickness of your tool.</source>
-        <translation type="vanished">Seleccioneu una àrea amb el ratolí, o premeu Esc per a eixir.
-Premeu Retorn per a capturar la pantalla.
-Feu clic amb el botó dret per a mostrar el selector de color.
-Utilitzeu la roda del ratolí per a canviar el gruix de l&apos;eina.</translation>
-    </message>
-    <message>
         <source>Unable to capture screen</source>
         <translatorcomment>Impossible capturar la pantalla</translatorcomment>
         <translation>Imposible capturar la pantalla</translation>
@@ -156,10 +146,6 @@ Press Space to open the side panel.</source>
     <message>
         <source>Copy</source>
         <translation>Copia</translation>
-    </message>
-    <message>
-        <source>Copies the selecion into the clipboard</source>
-        <translation type="vanished">Copia la selecció al porta-retalls</translation>
     </message>
     <message>
         <source>Copies the selection into the clipboard</source>

--- a/translations/Internationalization_es.ts
+++ b/translations/Internationalization_es.ts
@@ -642,7 +642,7 @@ Usa la rueda del ratón para cambiar el grosor de la herramienta.</translation>
     <message>
         <location filename="../src/tools/redo/redotool.cpp" line="42"/>
         <source>Redo the next modification</source>
-        <translation type="unfinished"></translation>
+        <translation>Rehacer la siguiente modificación</translation>
     </message>
 </context>
 <context>

--- a/translations/Internationalization_es.ts
+++ b/translations/Internationalization_es.ts
@@ -94,16 +94,6 @@ Presion Click Derecho para mostrar el selector de color.
 Usa la rueda del ratón para cambiar el grosor de la herramienta.
 Presiona Espacion para abrir el panel lateral.</translation>
     </message>
-    <message>
-        <source>Select an area with the mouse, or press Esc to exit.
-Press Enter to capture the screen.
-Press Right Click to show the color picker.
-Use the Mouse Wheel to change the thickness of your tool.</source>
-        <translation type="vanished">Selecciona un área con el ratón, o presiona Esc para salir.
-Presiona Enter para capturar la pantalla.
-Presion Click Derecho para mostrar el selector de color.
-Usa la rueda del ratón para cambiar el grosor de la herramienta.</translation>
-    </message>
 </context>
 <context>
     <name>CircleTool</name>
@@ -193,10 +183,6 @@ Usa la rueda del ratón para cambiar el grosor de la herramienta.</translation>
         <location filename="../src/tools/copy/copytool.cpp" line="43"/>
         <source>Copies the selection into the clipboard</source>
         <translation>Copia la selección al portapapeles</translation>
-    </message>
-    <message>
-        <source>Copies the selecion into the clipboard</source>
-        <translation type="vanished">Copia la selección al portapapeles</translation>
     </message>
 </context>
 <context>

--- a/translations/Internationalization_fr.ts
+++ b/translations/Internationalization_fr.ts
@@ -90,16 +90,6 @@ Use the Mouse Wheel to change the thickness of your tool.
 Press Space to open the side panel.</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>Select an area with the mouse, or press Esc to exit.
-Press Enter to capture the screen.
-Press Right Click to show the color picker.
-Use the Mouse Wheel to change the thickness of your tool.</source>
-        <translation type="vanished">Sélectionner une zone avec la souris, ou taper sur Echap pour quitter.
-Taper sur Entrée pour capturer l&apos;écran.
-Clic droit pour afficher la palette de couleurs.
-Utiliser la molette pour changer l&apos;épaisseur de l&apos;outil.</translation>
-    </message>
 </context>
 <context>
     <name>CircleTool</name>
@@ -189,10 +179,6 @@ Utiliser la molette pour changer l&apos;épaisseur de l&apos;outil.</translation
         <location filename="../src/tools/copy/copytool.cpp" line="43"/>
         <source>Copies the selection into the clipboard</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Copies the selecion into the clipboard</source>
-        <translation type="vanished">Copie la sélection dans le Presse-papier</translation>
     </message>
 </context>
 <context>

--- a/translations/Internationalization_ka.ts
+++ b/translations/Internationalization_ka.ts
@@ -90,16 +90,6 @@ Use the Mouse Wheel to change the thickness of your tool.
 Press Space to open the side panel.</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>Select an area with the mouse, or press Esc to exit.
-Press Enter to capture the screen.
-Press Right Click to show the color picker.
-Use the Mouse Wheel to change the thickness of your tool.</source>
-        <translation type="vanished">შეარჩიეთ ეკრანის არე მაუსით, ან დააწექით Esc-ს გამოსასვლელად.
-დააწექით Enter-ს ეკრანის გადასაღებად.
-წააწექით და დაიჭირეთ მაუსის მარჯვენა ღილაკი ფერის ასარჩევად.
-გამოიყენეთ მაუსის გორგოლაჭი ხელსაწყოს სისქის შესარევად.</translation>
-    </message>
 </context>
 <context>
     <name>CircleTool</name>
@@ -189,10 +179,6 @@ Use the Mouse Wheel to change the thickness of your tool.</source>
         <location filename="../src/tools/copy/copytool.cpp" line="43"/>
         <source>Copies the selection into the clipboard</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Copies the selecion into the clipboard</source>
-        <translation type="vanished">შერჩეულის გაცვლის ბუფერში კოპირება</translation>
     </message>
 </context>
 <context>

--- a/translations/Internationalization_pl.ts
+++ b/translations/Internationalization_pl.ts
@@ -93,16 +93,6 @@ Wciśnij Enter, aby wykonać zrzut ekranu.
 Prawy klik, aby pokazać próbnik kolorów.
 Spacja, aby pokazać panel boczny.</translation>
     </message>
-    <message>
-        <source>Select an area with the mouse, or press Esc to exit.
-Press Enter to capture the screen.
-Press Right Click to show the color picker.
-Use the Mouse Wheel to change the thickness of your tool.</source>
-        <translation type="vanished">Zaznacz obszar za pomocą myszy lub wciśnij Esc aby wyjść.
-Wciśnij Enter aby wykonać zrzut ekranu.
-Kliknij prawym przyciskiem myszy, aby pokazać próbnik kolorów.
-Użyj kółka myszy, aby zmienić grubość narzędzia do rysowania.</translation>
-    </message>
 </context>
 <context>
     <name>CircleTool</name>
@@ -192,10 +182,6 @@ Użyj kółka myszy, aby zmienić grubość narzędzia do rysowania.</translatio
         <location filename="../src/tools/copy/copytool.cpp" line="43"/>
         <source>Copies the selection into the clipboard</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Copies the selecion into the clipboard</source>
-        <translation type="vanished">Kopiuje zaznaczenie do schowka</translation>
     </message>
 </context>
 <context>

--- a/translations/Internationalization_ru.ts
+++ b/translations/Internationalization_ru.ts
@@ -90,16 +90,6 @@ Use the Mouse Wheel to change the thickness of your tool.
 Press Space to open the side panel.</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>Select an area with the mouse, or press Esc to exit.
-Press Enter to capture the screen.
-Press Right Click to show the color picker.
-Use the Mouse Wheel to change the thickness of your tool.</source>
-        <translation type="vanished">Выберите область с помощью мыши или нажмите Esc для выхода.
-Нажмите Enter, чтобы сделать снимок.
-Нажмите ПКМ, чтобы отобразить панель выбора цвета.
-Используйте колесико мыши, чтобы изменить толщину вашего инструмента.</translation>
-    </message>
 </context>
 <context>
     <name>CircleTool</name>
@@ -189,10 +179,6 @@ Use the Mouse Wheel to change the thickness of your tool.</source>
         <location filename="../src/tools/copy/copytool.cpp" line="43"/>
         <source>Copies the selection into the clipboard</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Copies the selecion into the clipboard</source>
-        <translation type="vanished">Скопировать выделение в буфер обмена</translation>
     </message>
 </context>
 <context>

--- a/translations/Internationalization_tr.ts
+++ b/translations/Internationalization_tr.ts
@@ -90,16 +90,6 @@ Use the Mouse Wheel to change the thickness of your tool.
 Press Space to open the side panel.</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>Select an area with the mouse, or press Esc to exit.
-Press Enter to capture the screen.
-Press Right Click to show the color picker.
-Use the Mouse Wheel to change the thickness of your tool.</source>
-        <translation type="vanished">Fareyle bir alan seçin veya çıkmak için Esc tuşuna basın.
-Ekranresmi almak için Enter tuşuna basın.
-Renk seçicisini göstermek için farenizin sağ butonuna basın.
-Araç boyutunu değiştirmek için fare tekerleğini kullanın.</translation>
-    </message>
 </context>
 <context>
     <name>CircleTool</name>
@@ -189,10 +179,6 @@ Araç boyutunu değiştirmek için fare tekerleğini kullanın.</translation>
         <location filename="../src/tools/copy/copytool.cpp" line="43"/>
         <source>Copies the selection into the clipboard</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Copies the selecion into the clipboard</source>
-        <translation type="vanished">Seçimi panoya kopyalar</translation>
     </message>
 </context>
 <context>

--- a/translations/Internationalization_zh_CN.ts
+++ b/translations/Internationalization_zh_CN.ts
@@ -77,16 +77,6 @@
 <context>
     <name>CaptureWidget</name>
     <message>
-        <source>Select an area with the mouse, or press Esc to exit.
-Press Enter to capture the screen.
-Press Right Click to show the color picker.
-Use the Mouse Wheel to change the thickness of your tool.</source>
-        <translation type="vanished">用鼠标选择一个区域,或按 Esc 退出。
-按 Enter 键捕捉屏幕。
-按住鼠标右键显示颜色选择器。
-使用鼠标滚轮来改变绘画工具的宽度。</translation>
-    </message>
-    <message>
         <location filename="../src/widgets/capture/capturewidget.cpp" line="81"/>
         <source>Unable to capture screen</source>
         <translatorcomment>无法捕获屏幕</translatorcomment>
@@ -194,10 +184,6 @@ Press Space to open the side panel.</source>
         <location filename="../src/tools/copy/copytool.cpp" line="43"/>
         <source>Copies the selection into the clipboard</source>
         <translation>复制选择到剪贴板</translation>
-    </message>
-    <message>
-        <source>Copies the selecion into the clipboard</source>
-        <translation type="vanished">复制选择到剪贴板</translation>
     </message>
 </context>
 <context>

--- a/translations/Internationalization_zh_TW.ts
+++ b/translations/Internationalization_zh_TW.ts
@@ -77,16 +77,6 @@
 <context>
     <name>CaptureWidget</name>
     <message>
-        <source>Select an area with the mouse, or press Esc to exit.
-Press Enter to capture the screen.
-Press Right Click to show the color picker.
-Use the Mouse Wheel to change the thickness of your tool.</source>
-        <translation type="vanished">用滑鼠選擇一個區域,或按 Esc 退出
-按 Enter 鍵擷取螢幕
-按滑鼠右鍵顯示顏色選擇器
-使用滑鼠滾輪來改變繪製工具的寬度</translation>
-    </message>
-    <message>
         <location filename="../src/widgets/capture/capturewidget.cpp" line="81"/>
         <source>Unable to capture screen</source>
         <translation>無法擷取螢幕</translation>
@@ -189,10 +179,6 @@ Press Space to open the side panel.</source>
         <location filename="../src/tools/copy/copytool.cpp" line="43"/>
         <source>Copies the selection into the clipboard</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Copies the selecion into the clipboard</source>
-        <translation type="vanished">複製到剪貼簿</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
- [x] Fix `TextTool` warning
```shell
src/tools/text/texttool.cpp:50: Class TextTool lacks Q_OBJECT macro
```
- [x] Add missing Spanis transation
- [x] Remove obsolete (vanished) translations