### PR TITLE
screengrabber: fix devicePixelRatio detection

### DIFF
--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -85,7 +85,9 @@ QPixmap ScreenGrabber::grabEntireDesktop(bool &ok) {
                   geometry.width(),
                   geometry.height())
               );
-    p.setDevicePixelRatio(QApplication::desktop()->devicePixelRatio());
+    auto screenNumber = QApplication::desktop()->screenNumber();
+    QScreen *screen = QApplication::screens()[screenNumber];
+    p.setDevicePixelRatio(screen->devicePixelRatio());
     return p;
 }
 

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -453,7 +453,7 @@ void CaptureWidget::mouseReleaseEvent(QMouseEvent *e) {
             newGeometry.setBottom(top);
         }
         m_selection->setGeometry(newGeometry);
-        m_context.selection = newGeometry;
+        m_context.selection = extendedRect(&newGeometry);
         updateSizeIndicator();
         m_buttonHandler->updatePosition(newGeometry);
         m_buttonHandler->show();
@@ -850,11 +850,14 @@ void CaptureWidget::redo() {
 QRect CaptureWidget::extendedSelection() const {
     if (!m_selection->isVisible())
         return QRect();
-    auto devicePixelRatio = m_context.screenshot.devicePixelRatio();
+    QRect r = m_selection->geometry();
+    return extendedRect(&r);
+}
 
-    QRect const &r = m_selection->geometry();
-    return QRect(r.left()   * devicePixelRatio,
-                 r.top()    * devicePixelRatio,
-                 r.width()  * devicePixelRatio,
-                 r.height() * devicePixelRatio);
+QRect CaptureWidget::extendedRect(QRect *r) const {
+    auto devicePixelRatio = m_context.screenshot.devicePixelRatio();
+    return QRect(r->left()   * devicePixelRatio,
+                 r->top()    * devicePixelRatio,
+                 r->width()  * devicePixelRatio,
+                 r->height() * devicePixelRatio);
 }

--- a/src/widgets/capture/capturewidget.h
+++ b/src/widgets/capture/capturewidget.h
@@ -130,6 +130,7 @@ private:
     void makeChild(QWidget *w);
 
     QRect extendedSelection() const;
+    QRect extendedRect(QRect *r) const;
 
     QUndoStack m_undoStack;
     QPointer<CaptureButton> m_sizeIndButton;


### PR DESCRIPTION
At least on two of my devices, `QApplication::desktop()->devicePixelRatio()` is always 0. This patch fixes detection of the `devicePixelRatio` by fetching the correct value from the screen that the current desktop is on, and also corrects the calculation of the selection area in `screengrabber` when the pixel ratio of the pixmap is set correctly.

The bug causes no problems on non-HiDPI devices or devices with integer scale factors for some reason that I haven't investigated yet (maybe it has a default value of 1 if 0 is fed into `setDevicePixelRatio`?). However, on my laptop with a scale factor of `1.5` (set through KDE System Settings on Xorg), flameshot breaks and the background is scaled improperly.

For reference, this is how my fractionally-scaled desktop should look like:
![screenshot_20180722_205120](https://user-images.githubusercontent.com/4532423/43045891-52f14ae2-8df3-11e8-9554-7fe66db05855.png)


And here is how it looks through flameshot before this patch:
![2018-07-22_20-51-45](https://user-images.githubusercontent.com/4532423/43045878-24a27706-8df3-11e8-8a05-5ee2aa6a897f.png)
