### PR TITLE
Fix image file saving

### DIFF
--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -41,18 +41,21 @@ bool ScreenshotSaver::saveToFilesystem(const QPixmap &capture,
     completePath += ".png";
     bool ok = capture.save(completePath);
     QString saveMessage;
+
     if (ok) {
         ConfigHandler().setSavePath(path);
         saveMessage = QObject::tr("Capture saved as ") + completePath;
     } else {
         saveMessage = QObject::tr("Error trying to save as ") + completePath;
     }
+
     SystemNotification().sendMessage(saveMessage);
     return ok;
 }
 
 bool ScreenshotSaver::saveToFilesystemGUI(const QPixmap &capture) {
     bool ok = false;
+
     while (!ok) {
         QString savePath = QFileDialog::getSaveFileName(
                     nullptr,
@@ -62,7 +65,13 @@ bool ScreenshotSaver::saveToFilesystemGUI(const QPixmap &capture) {
         if (savePath.isNull()) {
             break;
         }
+
+        if (!savePath.endsWith(".png")) {
+            savePath += ".png";
+        }
+
         ok = capture.save(savePath);
+
         if (ok) {
             QString pathNoFile = savePath.left(savePath.lastIndexOf("/"));
             ConfigHandler().setSavePath(pathNoFile);


### PR DESCRIPTION
This change ensures that the file name contains the PNG extension.

Currently the screenshots are saved as PNG only, so this only checks if the absolute path contains `.png`, it does not check the file suffix (`QFileInfo`).

Fixes #278