### PR TITLE
README.md: Add info about flameshot in Debian 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ There are packages available for a few distros:
 - [Arch](https://www.archlinux.org/packages/community/x86_64/flameshot/)
   + Snapshot also available via AUR: [flameshot-git](https://aur.archlinux.org/packages/flameshot-git).
 - [Debian 10+](https://tracker.debian.org/pkg/flameshot): `apt install flameshot`
+  + Package for Debian 9 ("Stretch") also [available via stretch-backports](https://backports.debian.org/).
 - [Ubuntu 18.04+](https://launchpad.net/ubuntu/+source/flameshot): `apt install flameshot`
 - [openSUSE](https://software.opensuse.org/package/flameshot)
 - [Void Linux](https://github.com/voidlinux/void-packages/tree/master/srcpkgs/flameshot) (`xbps-install flameshot`)


### PR DESCRIPTION
This commit adds information about flameshot in Debian 9 (via stretch-backports repository) in `README.md`.