### PR TITLE
Use absolute locations in translation files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Contributions are welcome! Here's how you can help:
 
 ## Translations
 
-Check this nice official documentation from QT docs as it explains how to translate for a project written with QT: https://doc.qt.io/qt-5/linguist-translators.html
+Check this nice official documentation from Qt docs as it explains how to translate for a project written with Qt: https://doc.qt.io/qt-5/linguist-translators.html
 
 #### Status:
 

--- a/src/cli/commandlineparser.cpp
+++ b/src/cli/commandlineparser.cpp
@@ -312,7 +312,7 @@ QString CommandLineParser::value(const CommandOption &option) const {
 }
 
 void CommandLineParser::printVersion() {
-    out << "Flameshot " << qApp->applicationVersion() << "\nCompiled with QT "
+    out << "Flameshot " << qApp->applicationVersion() << "\nCompiled with Qt "
         << static_cast<QString>(QT_VERSION_STR) << "\n";
 }
 

--- a/src/core/controller.h
+++ b/src/core/controller.h
@@ -72,8 +72,8 @@ private slots:
 private:
     Controller();
 
-    // replace QTimer::singleShot introduced in QT 5.4
-    // the actual target QT version is QT 5.3
+    // replace QTimer::singleShot introduced in Qt 5.4
+    // the actual target Qt version is 5.3
     void doLater(int msec, QObject *receiver, lambda func);
 
     QMap<uint, CaptureRequest> m_requestMap;

--- a/src/widgets/infowindow.cpp
+++ b/src/widgets/infowindow.cpp
@@ -115,7 +115,7 @@ void InfoWindow::initLabels() {
     QLabel *versionTitleLabel = new QLabel(tr("<u><b>Version</b></u>"), this);
     versionTitleLabel->setAlignment(Qt::AlignHCenter);
     m_layout->addWidget(versionTitleLabel);
-    QString versionMsg = "Flameshot " + QString(APP_VERSION) + "\nCompiled with QT "
+    QString versionMsg = "Flameshot " + QString(APP_VERSION) + "\nCompiled with Qt "
             + QT_VERSION_STR;
     QLabel *versionLabel = new QLabel(versionMsg, this);
     versionLabel->setAlignment(Qt::AlignHCenter);

--- a/translations/Internationalization_ca.ts
+++ b/translations/Internationalization_ca.ts
@@ -4,10 +4,12 @@
 <context>
     <name>AppLauncher</name>
     <message>
+        <location filename="../src/tools/launcher/applaunchertool.cpp" line="34"/>
         <source>App Launcher</source>
         <translation>Llançador d&apos;aplicacions</translation>
     </message>
     <message>
+        <location filename="../src/tools/launcher/applaunchertool.cpp" line="42"/>
         <source>Choose an app to open the capture</source>
         <translation>Trieu una aplicació per obrir la captura</translation>
     </message>
@@ -15,26 +17,33 @@
 <context>
     <name>AppLauncherWidget</name>
     <message>
+        <location filename="../src/tools/launcher/applauncherwidget.cpp" line="56"/>
         <source>Open With</source>
         <translation>Obrir Amb</translation>
     </message>
     <message>
+        <location filename="../src/tools/launcher/applauncherwidget.cpp" line="71"/>
         <source>Launch in terminal</source>
         <translation>Llançament a la terminal</translation>
     </message>
     <message>
+        <location filename="../src/tools/launcher/applauncherwidget.cpp" line="72"/>
         <source>Keep open after selection</source>
         <translation>Segueix obert després de la selecció</translation>
     </message>
     <message>
+        <location filename="../src/tools/launcher/applauncherwidget.cpp" line="99"/>
+        <location filename="../src/tools/launcher/applauncherwidget.cpp" line="111"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
+        <location filename="../src/tools/launcher/applauncherwidget.cpp" line="112"/>
         <source>Unable to launch in terminal.</source>
         <translation>No es pot iniciar a la terminal.</translation>
     </message>
     <message>
+        <location filename="../src/tools/launcher/applauncherwidget.cpp" line="99"/>
         <source>Unable to write in</source>
         <translation>No es pot escriure a</translation>
     </message>
@@ -42,10 +51,12 @@
 <context>
     <name>ArrowTool</name>
     <message>
+        <location filename="../src/tools/arrow/arrowtool.cpp" line="80"/>
         <source>Arrow</source>
         <translation>Fletxa</translation>
     </message>
     <message>
+        <location filename="../src/tools/arrow/arrowtool.cpp" line="88"/>
         <source>Sets the Arrow as the paint tool</source>
         <translation>Estableix la fletxa com a eina de dibuix</translation>
     </message>
@@ -53,10 +64,12 @@
 <context>
     <name>BlurTool</name>
     <message>
+        <location filename="../src/tools/blur/blurtool.cpp" line="34"/>
         <source>Blur</source>
         <translation>Desenfocament</translation>
     </message>
     <message>
+        <location filename="../src/tools/blur/blurtool.cpp" line="42"/>
         <source>Sets the Blur as the paint tool</source>
         <translation>Estableix el desenfocament com a eina de dibuix</translation>
     </message>
@@ -64,11 +77,13 @@
 <context>
     <name>CaptureWidget</name>
     <message>
+        <location filename="../src/widgets/capture/capturewidget.cpp" line="81"/>
         <source>Unable to capture screen</source>
         <translatorcomment>Impossible capturar la pantalla</translatorcomment>
         <translation>Imposible capturar la pantalla</translation>
     </message>
     <message>
+        <location filename="../src/widgets/capture/capturewidget.cpp" line="231"/>
         <source>Select an area with the mouse, or press Esc to exit.
 Press Enter to capture the screen.
 Press Right Click to show the color picker.
@@ -80,10 +95,12 @@ Press Space to open the side panel.</source>
 <context>
     <name>CircleTool</name>
     <message>
+        <location filename="../src/tools/circle/circletool.cpp" line="34"/>
         <source>Circle</source>
         <translation>Cercle</translation>
     </message>
     <message>
+        <location filename="../src/tools/circle/circletool.cpp" line="42"/>
         <source>Sets the Circle as the paint tool</source>
         <translation>Estableix el cercle com a eina de dibuix</translation>
     </message>
@@ -91,14 +108,17 @@ Press Space to open the side panel.</source>
 <context>
     <name>ColorPickerWidget</name>
     <message>
+        <location filename="../src/widgets/panel/colorpickerwidget.cpp" line="64"/>
         <source>Active color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/widgets/panel/colorpickerwidget.cpp" line="164"/>
         <source>Press ESC to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/widgets/panel/colorpickerwidget.cpp" line="166"/>
         <source>Grab Color</source>
         <translation type="unfinished"></translation>
     </message>
@@ -106,18 +126,22 @@ Press Space to open the side panel.</source>
 <context>
     <name>ConfigWindow</name>
     <message>
+        <location filename="../src/config/configwindow.cpp" line="41"/>
         <source>Configuration</source>
         <translation>Configuració</translation>
     </message>
     <message>
+        <location filename="../src/config/configwindow.cpp" line="63"/>
         <source>Interface</source>
         <translation>Interfície</translation>
     </message>
     <message>
+        <location filename="../src/config/configwindow.cpp" line="68"/>
         <source>Filename Editor</source>
         <translation>Editor de noms</translation>
     </message>
     <message>
+        <location filename="../src/config/configwindow.cpp" line="73"/>
         <source>General</source>
         <translation>General</translation>
     </message>
@@ -125,18 +149,22 @@ Press Space to open the side panel.</source>
 <context>
     <name>Controller</name>
     <message>
+        <location filename="../src/core/controller.cpp" line="174"/>
         <source>&amp;Configuration</source>
         <translation>&amp;Configuració</translation>
     </message>
     <message>
+        <location filename="../src/core/controller.cpp" line="177"/>
         <source>&amp;Information</source>
         <translation>&amp;Informació</translation>
     </message>
     <message>
+        <location filename="../src/core/controller.cpp" line="180"/>
         <source>&amp;Quit</source>
         <translation>&amp;Ix</translation>
     </message>
     <message>
+        <location filename="../src/core/controller.cpp" line="169"/>
         <source>&amp;Take Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,10 +172,12 @@ Press Space to open the side panel.</source>
 <context>
     <name>CopyTool</name>
     <message>
+        <location filename="../src/tools/copy/copytool.cpp" line="35"/>
         <source>Copy</source>
         <translation>Copia</translation>
     </message>
     <message>
+        <location filename="../src/tools/copy/copytool.cpp" line="43"/>
         <source>Copies the selection into the clipboard</source>
         <translation type="unfinished"></translation>
     </message>
@@ -155,6 +185,7 @@ Press Space to open the side panel.</source>
 <context>
     <name>DBusUtils</name>
     <message>
+        <location filename="../src/utils/dbusutils.cpp" line="43"/>
         <source>Unable to connect via DBus</source>
         <translation>Impossible connectar mitjançant DBus</translation>
     </message>
@@ -162,10 +193,12 @@ Press Space to open the side panel.</source>
 <context>
     <name>ExitTool</name>
     <message>
+        <location filename="../src/tools/exit/exittool.cpp" line="34"/>
         <source>Exit</source>
         <translation>Ix</translation>
     </message>
     <message>
+        <location filename="../src/tools/exit/exittool.cpp" line="42"/>
         <source>Leave the capture screen</source>
         <translation>Ix de la pantalla de captura</translation>
     </message>
@@ -173,38 +206,47 @@ Press Space to open the side panel.</source>
 <context>
     <name>FileNameEditor</name>
     <message>
+        <location filename="../src/config/filenameeditor.cpp" line="35"/>
         <source>Edit the name of your captures:</source>
         <translation>Editeu el nom de les vostres captures:</translation>
     </message>
     <message>
+        <location filename="../src/config/filenameeditor.cpp" line="39"/>
         <source>Edit:</source>
         <translation>Edita:</translation>
     </message>
     <message>
+        <location filename="../src/config/filenameeditor.cpp" line="41"/>
         <source>Preview:</source>
         <translation>Previsualització:</translation>
     </message>
     <message>
+        <location filename="../src/config/filenameeditor.cpp" line="78"/>
         <source>Save</source>
         <translation>Guarda</translation>
     </message>
     <message>
+        <location filename="../src/config/filenameeditor.cpp" line="80"/>
         <source>Saves the pattern</source>
         <translation>Guarda el patró</translation>
     </message>
     <message>
+        <location filename="../src/config/filenameeditor.cpp" line="82"/>
         <source>Reset</source>
         <translation>Reinicialitza</translation>
     </message>
     <message>
+        <location filename="../src/config/filenameeditor.cpp" line="85"/>
         <source>Restores the saved pattern</source>
         <translation>Restaura el patró guardat</translation>
     </message>
     <message>
+        <location filename="../src/config/filenameeditor.cpp" line="87"/>
         <source>Clear</source>
         <translation>Neteja</translation>
     </message>
     <message>
+        <location filename="../src/config/filenameeditor.cpp" line="91"/>
         <source>Deletes the name</source>
         <translation>Elimina el patró</translation>
     </message>
@@ -212,70 +254,92 @@ Press Space to open the side panel.</source>
 <context>
     <name>GeneneralConf</name>
     <message>
+        <location filename="../src/config/geneneralconf.cpp" line="132"/>
         <source>Show help message</source>
         <translation>Mostra el missatge d&apos;ajuda</translation>
     </message>
     <message>
+        <location filename="../src/config/geneneralconf.cpp" line="136"/>
         <source>Show the help message at the beginning in the capture mode.</source>
         <translation>Mostra el missatge d&apos;ajuda en iniciar el mode de captura.</translation>
     </message>
     <message>
+        <location filename="../src/config/geneneralconf.cpp" line="146"/>
+        <location filename="../src/config/geneneralconf.cpp" line="150"/>
         <source>Show desktop notifications</source>
         <translation>Mostra les notificacions d&apos;escriptori</translation>
     </message>
     <message>
+        <location filename="../src/config/geneneralconf.cpp" line="159"/>
         <source>Show tray icon</source>
         <translation>Mostra la icona en la barra de tasques</translation>
     </message>
     <message>
+        <location filename="../src/config/geneneralconf.cpp" line="163"/>
         <source>Show the systemtray icon</source>
         <translation>Mostra la icona en la barra de tasques</translation>
     </message>
     <message>
+        <location filename="../src/config/geneneralconf.cpp" line="78"/>
+        <location filename="../src/config/geneneralconf.cpp" line="184"/>
         <source>Import</source>
         <translation>Importar</translation>
     </message>
     <message>
+        <location filename="../src/config/geneneralconf.cpp" line="85"/>
+        <location filename="../src/config/geneneralconf.cpp" line="93"/>
+        <location filename="../src/config/geneneralconf.cpp" line="115"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
+        <location filename="../src/config/geneneralconf.cpp" line="85"/>
         <source>Unable to read file.</source>
         <translation>Impossible llegir el fitxer.</translation>
     </message>
     <message>
+        <location filename="../src/config/geneneralconf.cpp" line="93"/>
+        <location filename="../src/config/geneneralconf.cpp" line="115"/>
         <source>Unable to write file.</source>
         <translation>Impossible escriure al fitxer.</translation>
     </message>
     <message>
+        <location filename="../src/config/geneneralconf.cpp" line="101"/>
         <source>Save File</source>
         <translation>Guardar Arxiu</translation>
     </message>
     <message>
+        <location filename="../src/config/geneneralconf.cpp" line="122"/>
         <source>Confirm Reset</source>
         <translation>Confirmar Reset</translation>
     </message>
     <message>
+        <location filename="../src/config/geneneralconf.cpp" line="123"/>
         <source>Are you sure you want to reset the configuration?</source>
         <translation>Esteu segur que voleu reiniciar la configuració?</translation>
     </message>
     <message>
+        <location filename="../src/config/geneneralconf.cpp" line="174"/>
         <source>Configuration File</source>
         <translation>Fitxer de Configuració</translation>
     </message>
     <message>
+        <location filename="../src/config/geneneralconf.cpp" line="179"/>
         <source>Export</source>
         <translation>Exportar</translation>
     </message>
     <message>
+        <location filename="../src/config/geneneralconf.cpp" line="189"/>
         <source>Reset</source>
         <translation>Reset</translation>
     </message>
     <message>
+        <location filename="../src/config/geneneralconf.cpp" line="197"/>
         <source>Launch at startup</source>
         <translation>Llançament a l&apos;inici</translation>
     </message>
     <message>
+        <location filename="../src/config/geneneralconf.cpp" line="201"/>
         <source>Launch Flameshot</source>
         <translation type="unfinished"></translation>
     </message>
@@ -283,38 +347,48 @@ Press Space to open the side panel.</source>
 <context>
     <name>ImgurUploader</name>
     <message>
+        <location filename="../src/tools/imgur/imguruploader.cpp" line="47"/>
         <source>Upload to Imgur</source>
         <translation>Puja a Imgur</translation>
     </message>
     <message>
+        <location filename="../src/tools/imgur/imguruploader.cpp" line="53"/>
         <source>Uploading Image</source>
         <translation>S&apos;està pujant la imatge</translation>
     </message>
     <message>
+        <location filename="../src/tools/imgur/imguruploader.cpp" line="133"/>
         <source>Copy URL</source>
         <translation>Copia l&apos;URL</translation>
     </message>
     <message>
+        <location filename="../src/tools/imgur/imguruploader.cpp" line="134"/>
         <source>Open URL</source>
         <translation>Obri l&apos;URL</translation>
     </message>
     <message>
+        <location filename="../src/tools/imgur/imguruploader.cpp" line="136"/>
         <source>Image to Clipboard.</source>
         <translation>Imatge al porta-retalls.</translation>
     </message>
     <message>
+        <location filename="../src/tools/imgur/imguruploader.cpp" line="155"/>
+        <location filename="../src/tools/imgur/imguruploader.cpp" line="168"/>
         <source>Unable to open the URL.</source>
         <translation>No es pot obrir l&apos;URL.</translation>
     </message>
     <message>
+        <location filename="../src/tools/imgur/imguruploader.cpp" line="161"/>
         <source>URL copied to clipboard.</source>
         <translation>L&apos;URL s&apos;ha copiat al porta-retalls.</translation>
     </message>
     <message>
+        <location filename="../src/tools/imgur/imguruploader.cpp" line="174"/>
         <source>Screenshot copied to clipboard.</source>
         <translation>La captura s&apos;ha copiat al porta-retalls.</translation>
     </message>
     <message>
+        <location filename="../src/tools/imgur/imguruploader.cpp" line="135"/>
         <source>Delete image</source>
         <translation type="unfinished"></translation>
     </message>
@@ -322,10 +396,12 @@ Press Space to open the side panel.</source>
 <context>
     <name>ImgurUploaderTool</name>
     <message>
+        <location filename="../src/tools/imgur/imguruploadertool.cpp" line="35"/>
         <source>Image Uploader</source>
         <translation>Puja la imatge</translation>
     </message>
     <message>
+        <location filename="../src/tools/imgur/imguruploadertool.cpp" line="43"/>
         <source>Uploads the selection to Imgur</source>
         <translation>Puja la selecció a Imgur</translation>
     </message>
@@ -333,70 +409,87 @@ Press Space to open the side panel.</source>
 <context>
     <name>InfoWindow</name>
     <message>
+        <location filename="../src/widgets/infowindow.cpp" line="31"/>
         <source>About</source>
         <translation>Quant a</translation>
     </message>
     <message>
+        <location filename="../src/widgets/infowindow.cpp" line="48"/>
         <source>Right Click</source>
         <translation>Clic dret</translation>
     </message>
     <message>
+        <location filename="../src/widgets/infowindow.cpp" line="49"/>
         <source>Mouse Wheel</source>
         <translation>Roda del ratolí</translation>
     </message>
     <message>
+        <location filename="../src/widgets/infowindow.cpp" line="53"/>
         <source>Move selection 1px</source>
         <translation>Mou la selecció 1 px</translation>
     </message>
     <message>
+        <location filename="../src/widgets/infowindow.cpp" line="54"/>
         <source>Resize selection 1px</source>
         <translation>Redimensiona la selecció 1 px</translation>
     </message>
     <message>
+        <location filename="../src/widgets/infowindow.cpp" line="55"/>
         <source>Quit capture</source>
         <translation>Ix de la captura</translation>
     </message>
     <message>
+        <location filename="../src/widgets/infowindow.cpp" line="56"/>
         <source>Copy to clipboard</source>
         <translation>Copia al porta-retalls</translation>
     </message>
     <message>
+        <location filename="../src/widgets/infowindow.cpp" line="57"/>
         <source>Save selection as a file</source>
         <translation>Guarda la selecció com a fitxer</translation>
     </message>
     <message>
+        <location filename="../src/widgets/infowindow.cpp" line="58"/>
         <source>Undo the last modification</source>
         <translation>Desfés l&apos;última modificació</translation>
     </message>
     <message>
+        <location filename="../src/widgets/infowindow.cpp" line="59"/>
         <source>Show color picker</source>
         <translation>Mostra el selector de color</translation>
     </message>
     <message>
+        <location filename="../src/widgets/infowindow.cpp" line="60"/>
         <source>Change the tool&apos;s thickness</source>
         <translation>Canvia el gruix de l&apos;eina</translation>
     </message>
     <message>
+        <location filename="../src/widgets/infowindow.cpp" line="76"/>
         <source>Key</source>
         <translation>Tecla</translation>
     </message>
     <message>
+        <location filename="../src/widgets/infowindow.cpp" line="76"/>
         <source>Description</source>
         <translation>Descripció</translation>
     </message>
     <message>
+        <location filename="../src/widgets/infowindow.cpp" line="107"/>
         <source>&lt;u&gt;&lt;b&gt;License&lt;/b&gt;&lt;/u&gt;</source>
         <translation>&lt;u&gt;&lt;b&gt;Llicència&lt;/b&gt;&lt;/u&gt;</translation>
     </message>
     <message>
+        <location filename="../src/widgets/infowindow.cpp" line="115"/>
         <source>&lt;u&gt;&lt;b&gt;Version&lt;/b&gt;&lt;/u&gt;</source>
         <translation>&lt;u&gt;&lt;b&gt;Versió&lt;/b&gt;&lt;/u&gt;</translation>
     </message>
     <message>
+        <location filename="../src/widgets/infowindow.cpp" line="125"/>
         <source>&lt;u&gt;&lt;b&gt;Shortcuts&lt;/b&gt;&lt;/u&gt;</source>
         <translation>&lt;u&gt;&lt;b&gt;Dreceres&lt;/b&gt;&lt;/u&gt;</translation>
     </message>
     <message>
+        <location filename="../src/widgets/infowindow.cpp" line="65"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation>Dreceres disponibles en el mode de captura de pantalla.</translation>
     </message>
@@ -404,10 +497,12 @@ Press Space to open the side panel.</source>
 <context>
     <name>LineTool</name>
     <message>
+        <location filename="../src/tools/line/linetool.cpp" line="42"/>
         <source>Line</source>
         <translation>Línia</translation>
     </message>
     <message>
+        <location filename="../src/tools/line/linetool.cpp" line="50"/>
         <source>Sets the Line as the paint tool</source>
         <translation>Estableix la línia com a eina de dibuix</translation>
     </message>
@@ -415,10 +510,12 @@ Press Space to open the side panel.</source>
 <context>
     <name>MarkerTool</name>
     <message>
+        <location filename="../src/tools/marker/markertool.cpp" line="42"/>
         <source>Marker</source>
         <translation>Marcador</translation>
     </message>
     <message>
+        <location filename="../src/tools/marker/markertool.cpp" line="50"/>
         <source>Sets the Marker as the paint tool</source>
         <translation>Estableix el marcador com a eina de dibuix</translation>
     </message>
@@ -426,10 +523,12 @@ Press Space to open the side panel.</source>
 <context>
     <name>MoveTool</name>
     <message>
+        <location filename="../src/tools/move/movetool.cpp" line="34"/>
         <source>Move</source>
         <translation>Mou</translation>
     </message>
     <message>
+        <location filename="../src/tools/move/movetool.cpp" line="42"/>
         <source>Move the selection area</source>
         <translation>Mou la selecció</translation>
     </message>
@@ -437,10 +536,12 @@ Press Space to open the side panel.</source>
 <context>
     <name>PencilTool</name>
     <message>
+        <location filename="../src/tools/pencil/penciltool.cpp" line="30"/>
         <source>Pencil</source>
         <translation>Llapis</translation>
     </message>
     <message>
+        <location filename="../src/tools/pencil/penciltool.cpp" line="38"/>
         <source>Sets the Pencil as the paint tool</source>
         <translation>Estableix el llapis com a eina de dibuix</translation>
     </message>
@@ -448,10 +549,12 @@ Press Space to open the side panel.</source>
 <context>
     <name>PinTool</name>
     <message>
+        <location filename="../src/tools/pin/pintool.cpp" line="34"/>
         <source>Pin Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/tools/pin/pintool.cpp" line="42"/>
         <source>Pin image on the desktop</source>
         <translation type="unfinished"></translation>
     </message>
@@ -459,30 +562,42 @@ Press Space to open the side panel.</source>
 <context>
     <name>QObject</name>
     <message>
+        <location filename="../src/utils/screenshotsaver.cpp" line="84"/>
         <source>Save Error</source>
         <translation>S&apos;ha produït un error en guardar</translation>
     </message>
     <message>
+        <location filename="../src/utils/screenshotsaver.cpp" line="47"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="78"/>
         <source>Capture saved as </source>
         <translation>Anomena i guarda la captura </translation>
     </message>
     <message>
+        <location filename="../src/utils/screenshotsaver.cpp" line="49"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="81"/>
         <source>Error trying to save as </source>
         <translation>S&apos;ha produït un error en anomenar i guardar </translation>
     </message>
     <message>
+        <location filename="../src/main.cpp" line="72"/>
+        <location filename="../src/main.cpp" line="359"/>
+        <location filename="../src/main.cpp" line="383"/>
+        <location filename="../src/main.cpp" line="412"/>
         <source>Unable to connect via DBus</source>
         <translation>No es pot connectar mitjançant DBus</translation>
     </message>
     <message>
+        <location filename="../src/tools/launcher/openwithprogram.cpp" line="39"/>
         <source>Error</source>
         <translation type="unfinished">Error</translation>
     </message>
     <message>
+        <location filename="../src/tools/launcher/openwithprogram.cpp" line="40"/>
         <source>Unable to write in</source>
         <translation type="unfinished">No es pot escriure a</translation>
     </message>
     <message>
+        <location filename="../src/utils/screenshotsaver.cpp" line="33"/>
         <source>Capture saved to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
@@ -490,10 +605,12 @@ Press Space to open the side panel.</source>
 <context>
     <name>RectangleTool</name>
     <message>
+        <location filename="../src/tools/rectangle/rectangletool.cpp" line="34"/>
         <source>Rectangle</source>
         <translation>Rectangle</translation>
     </message>
     <message>
+        <location filename="../src/tools/rectangle/rectangletool.cpp" line="42"/>
         <source>Sets the Rectangle as the paint tool</source>
         <translation>Estableix el rectangle com a eina de dibuix</translation>
     </message>
@@ -501,10 +618,12 @@ Press Space to open the side panel.</source>
 <context>
     <name>RedoTool</name>
     <message>
+        <location filename="../src/tools/redo/redotool.cpp" line="34"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/tools/redo/redotool.cpp" line="42"/>
         <source>Redo the next modification</source>
         <translation type="unfinished"></translation>
     </message>
@@ -512,10 +631,12 @@ Press Space to open the side panel.</source>
 <context>
     <name>SaveTool</name>
     <message>
+        <location filename="../src/tools/save/savetool.cpp" line="35"/>
         <source>Save</source>
         <translation>Guarda</translation>
     </message>
     <message>
+        <location filename="../src/tools/save/savetool.cpp" line="43"/>
         <source>Save the capture</source>
         <translation>Guarda la captura</translation>
     </message>
@@ -523,6 +644,7 @@ Press Space to open the side panel.</source>
 <context>
     <name>ScreenGrabber</name>
     <message>
+        <location filename="../src/utils/screengrabber.cpp" line="70"/>
         <source>Unable to capture screen</source>
         <translation type="unfinished">Imposible capturar la pantalla</translation>
     </message>
@@ -530,10 +652,12 @@ Press Space to open the side panel.</source>
 <context>
     <name>SelectionTool</name>
     <message>
+        <location filename="../src/tools/selection/selectiontool.cpp" line="38"/>
         <source>Rectangular Selection</source>
         <translation>Selecció rectangular</translation>
     </message>
     <message>
+        <location filename="../src/tools/selection/selectiontool.cpp" line="46"/>
         <source>Sets the Selection as the paint tool</source>
         <translation>Estableix la selecció com a eina de dibuix</translation>
     </message>
@@ -541,10 +665,12 @@ Press Space to open the side panel.</source>
 <context>
     <name>SizeIndicatorTool</name>
     <message>
+        <location filename="../src/tools/sizeindicator/sizeindicatortool.cpp" line="34"/>
         <source>Selection Size Indicator</source>
         <translation>Indicador de mida de selecció</translation>
     </message>
     <message>
+        <location filename="../src/tools/sizeindicator/sizeindicatortool.cpp" line="42"/>
         <source>Shows the dimensions of the selection (X Y)</source>
         <translation>Mostra les mides de la selecció (X Y)</translation>
     </message>
@@ -552,86 +678,107 @@ Press Space to open the side panel.</source>
 <context>
     <name>StrftimeChooserWidget</name>
     <message>
+        <location filename="../src/config/strftimechooserwidget.cpp" line="47"/>
         <source>Century (00-99)</source>
         <translation>Segle (00-99)</translation>
     </message>
     <message>
+        <location filename="../src/config/strftimechooserwidget.cpp" line="48"/>
         <source>Year (00-99)</source>
         <translation>Any (00-99)</translation>
     </message>
     <message>
+        <location filename="../src/config/strftimechooserwidget.cpp" line="49"/>
         <source>Year (2000)</source>
         <translation>Any (2000)</translation>
     </message>
     <message>
+        <location filename="../src/config/strftimechooserwidget.cpp" line="50"/>
         <source>Month Name (jan)</source>
         <translation>Nom del mes (jul)</translation>
     </message>
     <message>
+        <location filename="../src/config/strftimechooserwidget.cpp" line="51"/>
         <source>Month Name (january)</source>
         <translation>Nom del mes (juliol)</translation>
     </message>
     <message>
+        <location filename="../src/config/strftimechooserwidget.cpp" line="52"/>
         <source>Month (01-12)</source>
         <translation>Mes (01-12)</translation>
     </message>
     <message>
+        <location filename="../src/config/strftimechooserwidget.cpp" line="53"/>
         <source>Week Day (1-7)</source>
         <translation>Dia de la setmana (1-7)</translation>
     </message>
     <message>
+        <location filename="../src/config/strftimechooserwidget.cpp" line="54"/>
         <source>Week (01-53)</source>
         <translation>Setmana (01-53)</translation>
     </message>
     <message>
+        <location filename="../src/config/strftimechooserwidget.cpp" line="55"/>
         <source>Day Name (mon)</source>
         <translation>Nom del dia (dg)</translation>
     </message>
     <message>
+        <location filename="../src/config/strftimechooserwidget.cpp" line="56"/>
         <source>Day Name (monday)</source>
         <translation>Nom del dia (diumenge)</translation>
     </message>
     <message>
+        <location filename="../src/config/strftimechooserwidget.cpp" line="57"/>
         <source>Day (01-31)</source>
         <translation>Dia (01-31)</translation>
     </message>
     <message>
+        <location filename="../src/config/strftimechooserwidget.cpp" line="58"/>
         <source>Day of Month (1-31)</source>
         <translation>Dia del mes (1-31)</translation>
     </message>
     <message>
+        <location filename="../src/config/strftimechooserwidget.cpp" line="59"/>
         <source>Day (001-366)</source>
         <translation>Dia (001-366)</translation>
     </message>
     <message>
+        <location filename="../src/config/strftimechooserwidget.cpp" line="62"/>
         <source>Hour (00-23)</source>
         <translation>Hora (00-23)</translation>
     </message>
     <message>
+        <location filename="../src/config/strftimechooserwidget.cpp" line="63"/>
         <source>Hour (01-12)</source>
         <translation>Hora (01-12)</translation>
     </message>
     <message>
+        <location filename="../src/config/strftimechooserwidget.cpp" line="64"/>
         <source>Minute (00-59)</source>
         <translation>Minut (00-59)</translation>
     </message>
     <message>
+        <location filename="../src/config/strftimechooserwidget.cpp" line="65"/>
         <source>Second (00-59)</source>
         <translation>Segon (00-59)</translation>
     </message>
     <message>
+        <location filename="../src/config/strftimechooserwidget.cpp" line="66"/>
         <source>Full Date (%m/%d/%y)</source>
         <translation>Data (%m/%d/%y)</translation>
     </message>
     <message>
+        <location filename="../src/config/strftimechooserwidget.cpp" line="67"/>
         <source>Full Date (%Y-%m-%d)</source>
         <translation>Data (%Y-%m-%d)</translation>
     </message>
     <message>
+        <location filename="../src/config/strftimechooserwidget.cpp" line="60"/>
         <source>Time (%H-%M-%S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/config/strftimechooserwidget.cpp" line="61"/>
         <source>Time (%H-%M)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -639,6 +786,7 @@ Press Space to open the side panel.</source>
 <context>
     <name>SystemNotification</name>
     <message>
+        <location filename="../src/utils/systemnotification.cpp" line="28"/>
         <source>Flameshot Info</source>
         <translation type="unfinished"></translation>
     </message>
@@ -646,18 +794,22 @@ Press Space to open the side panel.</source>
 <context>
     <name>TextConfig</name>
     <message>
+        <location filename="../src/tools/text/textconfig.cpp" line="49"/>
         <source>StrikeOut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/tools/text/textconfig.cpp" line="56"/>
         <source>Underline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/tools/text/textconfig.cpp" line="63"/>
         <source>Bold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/tools/text/textconfig.cpp" line="70"/>
         <source>Italic</source>
         <translation type="unfinished"></translation>
     </message>
@@ -665,10 +817,12 @@ Press Space to open the side panel.</source>
 <context>
     <name>TextTool</name>
     <message>
+        <location filename="../src/tools/text/texttool.cpp" line="50"/>
         <source>Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/tools/text/texttool.cpp" line="58"/>
         <source>Add text to your capture</source>
         <translation type="unfinished"></translation>
     </message>
@@ -676,30 +830,37 @@ Press Space to open the side panel.</source>
 <context>
     <name>UIcolorEditor</name>
     <message>
+        <location filename="../src/config/uicoloreditor.cpp" line="30"/>
         <source>UI Color Editor</source>
         <translation>Editor de color de la interfície</translation>
     </message>
     <message>
+        <location filename="../src/config/uicoloreditor.cpp" line="93"/>
         <source>Change the color moving the selectors and see the changes in the preview buttons.</source>
         <translation>Canvieu el color movent els selectors i observeu els canvis en els botons de previsualització.</translation>
     </message>
     <message>
+        <location filename="../src/config/uicoloreditor.cpp" line="103"/>
         <source>Select a Button to modify it</source>
         <translation>Seleccioneu un botó per a modificar-lo</translation>
     </message>
     <message>
+        <location filename="../src/config/uicoloreditor.cpp" line="112"/>
         <source>Main Color</source>
         <translation>Color principal</translation>
     </message>
     <message>
+        <location filename="../src/config/uicoloreditor.cpp" line="116"/>
         <source>Click on this button to set the edition mode of the main color.</source>
         <translation>Feu clic en aquest botó per a aplicar el mode d&apos;edició per al color principal.</translation>
     </message>
     <message>
+        <location filename="../src/config/uicoloreditor.cpp" line="127"/>
         <source>Contrast Color</source>
         <translation>Color de contrast</translation>
     </message>
     <message>
+        <location filename="../src/config/uicoloreditor.cpp" line="132"/>
         <source>Click on this button to set the edition mode of the contrast color.</source>
         <translation>Feu clic en aquest botó per a aplicar el mode d&apos;edició per al color de contrast.</translation>
     </message>
@@ -707,10 +868,12 @@ Press Space to open the side panel.</source>
 <context>
     <name>UndoTool</name>
     <message>
+        <location filename="../src/tools/undo/undotool.cpp" line="34"/>
         <source>Undo</source>
         <translation>Desfés</translation>
     </message>
     <message>
+        <location filename="../src/tools/undo/undotool.cpp" line="42"/>
         <source>Undo the last modification</source>
         <translation>Desfés l&apos;última modificació</translation>
     </message>
@@ -718,14 +881,17 @@ Press Space to open the side panel.</source>
 <context>
     <name>VisualsEditor</name>
     <message>
+        <location filename="../src/config/visualseditor.cpp" line="53"/>
         <source>Opacity of area outside selection:</source>
         <translation>Opacitat de la zona fora de la selecció:</translation>
     </message>
     <message>
+        <location filename="../src/config/visualseditor.cpp" line="77"/>
         <source>Button Selection</source>
         <translation>Selecció de botó</translation>
     </message>
     <message>
+        <location filename="../src/config/visualseditor.cpp" line="83"/>
         <source>Select All</source>
         <translation>Selecciona-ho tot</translation>
     </message>

--- a/translations/Internationalization_es.ts
+++ b/translations/Internationalization_es.ts
@@ -565,13 +565,13 @@ Presiona Espacion para abrir el panel lateral.</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/utils/screenshotsaver.cpp" line="75"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="84"/>
         <source>Save Error</source>
         <translation>Error al Guardar</translation>
     </message>
     <message>
-        <location filename="../src/utils/screenshotsaver.cpp" line="46"/>
-        <location filename="../src/utils/screenshotsaver.cpp" line="69"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="47"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="78"/>
         <source>Capture saved as </source>
         <translation>Captura guardada como </translation>
     </message>
@@ -581,8 +581,8 @@ Presiona Espacion para abrir el panel lateral.</translation>
         <translation>Captura guardada en el portapapeles</translation>
     </message>
     <message>
-        <location filename="../src/utils/screenshotsaver.cpp" line="48"/>
-        <location filename="../src/utils/screenshotsaver.cpp" line="72"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="49"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="81"/>
         <source>Error trying to save as </source>
         <translation>Error intentando guardar como </translation>
     </message>

--- a/translations/Internationalization_fr.ts
+++ b/translations/Internationalization_fr.ts
@@ -561,13 +561,13 @@ Press Space to open the side panel.</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/utils/screenshotsaver.cpp" line="75"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="84"/>
         <source>Save Error</source>
         <translation>Erreur lors de la sauvegarde</translation>
     </message>
     <message>
-        <location filename="../src/utils/screenshotsaver.cpp" line="46"/>
-        <location filename="../src/utils/screenshotsaver.cpp" line="69"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="47"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="78"/>
         <source>Capture saved as </source>
         <translation>Capture d&apos;écran sauvegardée sous </translation>
     </message>
@@ -577,8 +577,8 @@ Press Space to open the side panel.</source>
         <translation>Capture d&apos;écran copiée dans le Presse-papier</translation>
     </message>
     <message>
-        <location filename="../src/utils/screenshotsaver.cpp" line="48"/>
-        <location filename="../src/utils/screenshotsaver.cpp" line="72"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="49"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="81"/>
         <source>Error trying to save as </source>
         <translation>Erreur lors de la sauvegarde sous </translation>
     </message>

--- a/translations/Internationalization_ka.ts
+++ b/translations/Internationalization_ka.ts
@@ -561,13 +561,13 @@ Press Space to open the side panel.</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/utils/screenshotsaver.cpp" line="75"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="84"/>
         <source>Save Error</source>
         <translation>შეცდომა შენახვისას</translation>
     </message>
     <message>
-        <location filename="../src/utils/screenshotsaver.cpp" line="46"/>
-        <location filename="../src/utils/screenshotsaver.cpp" line="69"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="47"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="78"/>
         <source>Capture saved as </source>
         <translation>სურათი შენახულია როგორც: </translation>
     </message>
@@ -577,8 +577,8 @@ Press Space to open the side panel.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/screenshotsaver.cpp" line="48"/>
-        <location filename="../src/utils/screenshotsaver.cpp" line="72"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="49"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="81"/>
         <source>Error trying to save as </source>
         <translation>შეცდომა მცდელობისას შენახულიყო როგორც: </translation>
     </message>

--- a/translations/Internationalization_pl.ts
+++ b/translations/Internationalization_pl.ts
@@ -564,13 +564,13 @@ Spacja, aby pokazać panel boczny.</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/utils/screenshotsaver.cpp" line="75"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="84"/>
         <source>Save Error</source>
         <translation>Błąd zapisu</translation>
     </message>
     <message>
-        <location filename="../src/utils/screenshotsaver.cpp" line="46"/>
-        <location filename="../src/utils/screenshotsaver.cpp" line="69"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="47"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="78"/>
         <source>Capture saved as </source>
         <translation>Zaznaczenie zapisano jako </translation>
     </message>
@@ -580,8 +580,8 @@ Spacja, aby pokazać panel boczny.</translation>
         <translation>Zrzut skopiowano do schowka</translation>
     </message>
     <message>
-        <location filename="../src/utils/screenshotsaver.cpp" line="48"/>
-        <location filename="../src/utils/screenshotsaver.cpp" line="72"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="49"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="81"/>
         <source>Error trying to save as </source>
         <translation>Błąd przy próbie zapisu jako </translation>
     </message>

--- a/translations/Internationalization_ru.ts
+++ b/translations/Internationalization_ru.ts
@@ -561,13 +561,13 @@ Press Space to open the side panel.</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/utils/screenshotsaver.cpp" line="75"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="84"/>
         <source>Save Error</source>
         <translation>Ошибка сохранения</translation>
     </message>
     <message>
-        <location filename="../src/utils/screenshotsaver.cpp" line="46"/>
-        <location filename="../src/utils/screenshotsaver.cpp" line="69"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="47"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="78"/>
         <source>Capture saved as </source>
         <translation>Сохранить снимок как </translation>
     </message>
@@ -577,8 +577,8 @@ Press Space to open the side panel.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/screenshotsaver.cpp" line="48"/>
-        <location filename="../src/utils/screenshotsaver.cpp" line="72"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="49"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="81"/>
         <source>Error trying to save as </source>
         <translation>Ошибка при попытке сохранить как </translation>
     </message>

--- a/translations/Internationalization_tr.ts
+++ b/translations/Internationalization_tr.ts
@@ -118,7 +118,7 @@ Yan paneli açmak için Boşluk tuşuna basın.</translation>
     <message>
         <location filename="../src/widgets/panel/colorpickerwidget.cpp" line="164"/>
         <source>Press ESC to cancel</source>
-        <translation>Çıkmak için ESC'ye tıklayın</translation>
+        <translation>Çıkmak için ESC&apos;ye tıklayın</translation>
     </message>
     <message>
         <location filename="../src/widgets/panel/colorpickerwidget.cpp" line="166"/>
@@ -565,13 +565,13 @@ Yan paneli açmak için Boşluk tuşuna basın.</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/utils/screenshotsaver.cpp" line="75"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="84"/>
         <source>Save Error</source>
         <translation>Kaydetme Hatası</translation>
     </message>
     <message>
-        <location filename="../src/utils/screenshotsaver.cpp" line="46"/>
-        <location filename="../src/utils/screenshotsaver.cpp" line="69"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="47"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="78"/>
         <source>Capture saved as </source>
         <translation>Yakalama farklı kaydedildi </translation>
     </message>
@@ -581,8 +581,8 @@ Yan paneli açmak için Boşluk tuşuna basın.</translation>
         <translation>Yakalama panoya kaydedildi</translation>
     </message>
     <message>
-        <location filename="../src/utils/screenshotsaver.cpp" line="48"/>
-        <location filename="../src/utils/screenshotsaver.cpp" line="72"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="49"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="81"/>
         <source>Error trying to save as </source>
         <translation>Farklı kaydetmeye çalışılırken hata oluştu </translation>
     </message>

--- a/translations/Internationalization_zh_CN.ts
+++ b/translations/Internationalization_zh_CN.ts
@@ -566,13 +566,13 @@ Press Space to open the side panel.</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/utils/screenshotsaver.cpp" line="75"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="84"/>
         <source>Save Error</source>
         <translation>保存错误</translation>
     </message>
     <message>
-        <location filename="../src/utils/screenshotsaver.cpp" line="46"/>
-        <location filename="../src/utils/screenshotsaver.cpp" line="69"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="47"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="78"/>
         <source>Capture saved as </source>
         <translation>捕获已保存为 </translation>
     </message>
@@ -582,8 +582,8 @@ Press Space to open the side panel.</source>
         <translation>捕获已保存至剪贴板</translation>
     </message>
     <message>
-        <location filename="../src/utils/screenshotsaver.cpp" line="48"/>
-        <location filename="../src/utils/screenshotsaver.cpp" line="72"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="49"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="81"/>
         <source>Error trying to save as </source>
         <translation>尝试另存为时出错 </translation>
     </message>

--- a/translations/Internationalization_zh_TW.ts
+++ b/translations/Internationalization_zh_TW.ts
@@ -561,13 +561,13 @@ Press Space to open the side panel.</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/utils/screenshotsaver.cpp" line="75"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="84"/>
         <source>Save Error</source>
         <translation>存檔錯誤</translation>
     </message>
     <message>
-        <location filename="../src/utils/screenshotsaver.cpp" line="46"/>
-        <location filename="../src/utils/screenshotsaver.cpp" line="69"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="47"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="78"/>
         <source>Capture saved as </source>
         <translation>截圖已另存為 </translation>
     </message>
@@ -577,8 +577,8 @@ Press Space to open the side panel.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/screenshotsaver.cpp" line="48"/>
-        <location filename="../src/utils/screenshotsaver.cpp" line="72"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="49"/>
+        <location filename="../src/utils/screenshotsaver.cpp" line="81"/>
         <source>Error trying to save as </source>
         <translation>嘗試另存新檔時發生錯誤 </translation>
     </message>


### PR DESCRIPTION
They provide context when using Qt Liguist, as it shows the source code where it is being used.

Translation files were updated with the following command, which also fixed some strings in the Turkish translation:

```shell
lupdate -locations absolute -no-obsolete flameshot.pro
```

Also replaced QT (capital T) with Qt, as the latter is the correct name.