### PR TITLE
Fix most of the issues reported by cppcheck

### DIFF
--- a/src/core/capturerequest.h
+++ b/src/core/capturerequest.h
@@ -65,15 +65,15 @@ private:
 
 using eTask = CaptureRequest::ExportTask;
 
-inline eTask operator|(eTask a, eTask b) {
+inline eTask operator|(const eTask &a, const eTask &b) {
     return static_cast<eTask>(static_cast<int>(a) | static_cast<int>(b));
 }
 
-inline eTask operator&(eTask a, eTask b) {
+inline eTask operator&(const eTask &a, const eTask &b) {
     return static_cast<eTask>(static_cast<int>(a) & static_cast<int>(b));
 }
 
-inline eTask& operator|=(eTask &a, eTask b) {
+inline eTask& operator|=(eTask &a, const eTask &b) {
     a = static_cast<eTask>(static_cast<int>(a) | static_cast<int>(b));
     return a;
 }

--- a/src/tools/abstractactiontool.h
+++ b/src/tools/abstractactiontool.h
@@ -24,7 +24,7 @@ class AbstractActionTool : public CaptureTool {
 public:
     explicit AbstractActionTool(QObject *parent = nullptr);
 
-    bool isValid() const;
+    bool isValid() const override;
     bool isSelectable() const override;
     bool showMousePreview() const override;
 

--- a/src/tools/abstractpathtool.h
+++ b/src/tools/abstractpathtool.h
@@ -24,8 +24,8 @@ class AbstractPathTool : public CaptureTool {
 public:
     explicit AbstractPathTool(QObject *parent = nullptr);
 
-    bool isValid() const;
-    bool closeOnButtonPressed() const;
+    bool isValid() const override;
+    bool closeOnButtonPressed() const override;
     bool isSelectable() const override;
     bool showMousePreview() const override;
 

--- a/src/tools/abstracttwopointtool.h
+++ b/src/tools/abstracttwopointtool.h
@@ -24,8 +24,8 @@ class AbstractTwoPointTool : public CaptureTool {
 public:
     explicit AbstractTwoPointTool(QObject *parent = nullptr);
 
-    bool isValid() const;
-    bool closeOnButtonPressed() const;
+    bool isValid() const override;
+    bool closeOnButtonPressed() const override;
     bool isSelectable() const override;
     bool showMousePreview() const override;
 

--- a/src/tools/imgur/imguruploader.h
+++ b/src/tools/imgur/imguruploader.h
@@ -33,7 +33,7 @@ class NotificationWidget;
 class ImgurUploader : public QWidget {
     Q_OBJECT
 public:
-    explicit ImgurUploader(const QPixmap &p, QWidget *parent = nullptr);
+    explicit ImgurUploader(const QPixmap &capture, QWidget *parent = nullptr);
 
 private slots:
     void handleReply(QNetworkReply *reply);

--- a/src/utils/dbusutils.cpp
+++ b/src/utils/dbusutils.cpp
@@ -38,8 +38,8 @@ void DBusUtils::connectPrintCapture(QDBusConnection &session, uint id) {
                        SLOT(captureFailed(uint)));
 }
 
-void DBusUtils::checkDBusConnection(const QDBusConnection &c) {
-    if (!c.isConnected()) {
+void DBusUtils::checkDBusConnection(const QDBusConnection &connection) {
+    if (!connection.isConnected()) {
         SystemNotification().sendMessage(tr("Unable to connect via DBus"));
         qApp->exit();
     }

--- a/src/utils/desktopfileparse.h
+++ b/src/utils/desktopfileparse.h
@@ -29,9 +29,9 @@ struct DesktopAppData {
     DesktopAppData() : showInTerminal() {}
 
     DesktopAppData(
-            QString name,
-            QString description,
-            QString exec,
+            const QString &name,
+            const QString &description,
+            const QString &exec,
             QIcon icon) :
         name(name),
         description(description),

--- a/src/utils/systemnotification.cpp
+++ b/src/utils/systemnotification.cpp
@@ -20,7 +20,7 @@ SystemNotification::SystemNotification(QObject *parent) : QObject(parent) {
 }
 #else
 SystemNotification::SystemNotification(QObject *parent) : QObject(parent) {
-
+    m_interface = null;
 }
 #endif
 

--- a/src/utils/systemnotification.cpp
+++ b/src/utils/systemnotification.cpp
@@ -20,7 +20,7 @@ SystemNotification::SystemNotification(QObject *parent) : QObject(parent) {
 }
 #else
 SystemNotification::SystemNotification(QObject *parent) : QObject(parent) {
-    m_interface = null;
+    m_interface = nullptr;
 }
 #endif
 

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -49,7 +49,7 @@
 
 // enableSaveWIndow
 CaptureWidget::CaptureWidget(const uint id, const QString &savePath,
-                             bool fullscreen, QWidget *parent) :
+                             bool fullScreen, QWidget *parent) :
     QWidget(parent), m_mouseIsClicked(false), m_rightClick(false),
     m_newSelection(false), m_grabbing(false), m_captureDone(false),
     m_previewEnabled(true), m_activeButton(nullptr),
@@ -66,14 +66,14 @@ CaptureWidget::CaptureWidget(const uint id, const QString &savePath,
     m_showInitialMsg = m_config.showHelpValue();
     m_opacity = m_config.contrastOpacityValue();
     setMouseTracking(true);
-    initContext(savePath, fullscreen);
+    initContext(savePath, fullScreen);
     initShortcuts();
 
 #ifdef Q_OS_WIN
     // Top left of the whole set of screens
     QPoint topLeft(0,0);
 #endif
-    if (fullscreen) {
+    if (fullScreen) {
         // Grab Screenshot
         bool ok = true;
         m_context.screenshot = ScreenGrabber().grabEntireDesktop(ok);

--- a/src/widgets/capture/selectionwidget.h
+++ b/src/widgets/capture/selectionwidget.h
@@ -39,7 +39,7 @@ public:
 
     explicit SelectionWidget(const QColor &c, QWidget *parent = nullptr);
 
-    SideType getMouseSide(const QPoint &p) const;
+    SideType getMouseSide(const QPoint &point) const;
     QVector<QRect> handlerAreas();
 
     void setGeometryAnimated(const QRect &r);


### PR DESCRIPTION
This aims to fix most of the issues reported by `cppcheck`:

**Command**:
```shell
cppcheck \
	--error-exitcode=1 \
	--report-progress \
	--enable=all \
	--inconclusive \
	--std=c++11 \
	--std=c++14 \
	-i src/third-party/ \
	src/ \
	> /tmp/flameshot-cppcheck.log 2>&1
```

<details>
<summary>Full output</summary>

```
Checking src/cli/commandargument.cpp ...
1/75 files checked 1% done
Checking src/cli/commandlineparser.cpp ...
[src/cli/commandlineparser.h:30]: (performance, inconclusive) Technically the member function 'CommandLineParser::rootArgument' can be static.
[src/cli/commandlineparser.cpp:314] -> [src/cli/commandlineparser.h:75]: (performance, inconclusive) Technically the member function 'CommandLineParser::printVersion' can be static.
[src/cli/commandlineparser.cpp:319] -> [src/cli/commandlineparser.h:76]: (style, inconclusive) Technically the member function 'CommandLineParser::printHelp' can be const.
2/75 files checked 2% done
Checking src/cli/commandoption.cpp ...
3/75 files checked 4% done
Checking src/config/buttonlistview.cpp ...
4/75 files checked 5% done
Checking src/config/clickablelabel.cpp ...
5/75 files checked 6% done
Checking src/config/configwindow.cpp ...
6/75 files checked 8% done
Checking src/config/extendedslider.cpp ...
7/75 files checked 9% done
Checking src/config/filenameeditor.cpp ...
8/75 files checked 10% done
Checking src/config/geneneralconf.cpp ...
Checking src/config/geneneralconf.cpp: Q_OS_LINUX;Q_OS_UNIX...
9/75 files checked 12% done
Checking src/config/strftimechooserwidget.cpp ...
10/75 files checked 13% done
Checking src/config/uicoloreditor.cpp ...
11/75 files checked 14% done
Checking src/config/visualseditor.cpp ...
12/75 files checked 16% done
Checking src/core/capturerequest.cpp ...
[src/core/capturerequest.h:68]: (performance, inconclusive) Function parameter 'a' should be passed by const reference.
[src/core/capturerequest.h:68]: (performance, inconclusive) Function parameter 'b' should be passed by const reference.
[src/core/capturerequest.h:72]: (performance, inconclusive) Function parameter 'a' should be passed by const reference.
[src/core/capturerequest.h:72]: (performance, inconclusive) Function parameter 'b' should be passed by const reference.
[src/core/capturerequest.h:76]: (performance, inconclusive) Function parameter 'b' should be passed by const reference.
13/75 files checked 17% done
Checking src/core/controller.cpp ...
Checking src/core/controller.cpp: Q_OS_LINUX;Q_OS_UNIX...
Checking src/core/controller.cpp: Q_OS_WIN...
14/75 files checked 18% done
Checking src/core/flameshotdbusadapter.cpp ...
15/75 files checked 20% done
Checking src/core/globalshortcutfilter.cpp ...
16/75 files checked 21% done
Checking src/main.cpp ...
Checking src/main.cpp: Q_OS_LINUX;Q_OS_UNIX...
17/75 files checked 22% done
Checking src/tools/abstractactiontool.cpp ...
[src/tools/capturetool.h:71] -> [src/tools/abstractactiontool.h:27]: (style) The function 'isValid' overrides a function in a base class but is not marked with a 'override' specifier.
18/75 files checked 24% done
Checking src/tools/abstractpathtool.cpp ...
[src/tools/capturetool.h:71] -> [src/tools/abstractpathtool.h:27]: (style) The function 'isValid' overrides a function in a base class but is not marked with a 'override' specifier.
[src/tools/capturetool.h:74] -> [src/tools/abstractpathtool.h:28]: (style) The function 'closeOnButtonPressed' overrides a function in a base class but is not marked with a 'override' specifier.
19/75 files checked 25% done
Checking src/tools/abstracttwopointtool.cpp ...
[src/tools/capturetool.h:71] -> [src/tools/abstracttwopointtool.h:27]: (style) The function 'isValid' overrides a function in a base class but is not marked with a 'override' specifier.
[src/tools/capturetool.h:74] -> [src/tools/abstracttwopointtool.h:28]: (style) The function 'closeOnButtonPressed' overrides a function in a base class but is not marked with a 'override' specifier.
20/75 files checked 26% done
Checking src/tools/arrow/arrowtool.cpp ...
21/75 files checked 28% done
Checking src/tools/blur/blurtool.cpp ...
22/75 files checked 29% done
Checking src/tools/capturecontext.cpp ...
23/75 files checked 30% done
Checking src/tools/circle/circletool.cpp ...
24/75 files checked 32% done
Checking src/tools/copy/copytool.cpp ...
25/75 files checked 33% done
Checking src/tools/exit/exittool.cpp ...
26/75 files checked 34% done
Checking src/tools/imgur/imguruploader.cpp ...
[src/tools/imgur/imguruploader.h:36] -> [src/tools/imgur/imguruploader.cpp:44]: (style, inconclusive) Function 'ImgurUploader' argument 1 names different: declaration 'p' definition 'capture'.
27/75 files checked 36% done
Checking src/tools/imgur/imguruploadertool.cpp ...
28/75 files checked 37% done
Checking src/tools/launcher/applaunchertool.cpp ...
29/75 files checked 38% done
Checking src/tools/launcher/applauncherwidget.cpp ...
30/75 files checked 40% done
Checking src/tools/launcher/launcheritemdelegate.cpp ...
31/75 files checked 41% done
Checking src/tools/launcher/openwithprogram.cpp ...
Checking src/tools/launcher/openwithprogram.cpp: Q_OS_WIN...
32/75 files checked 42% done
Checking src/tools/launcher/terminallauncher.cpp ...
33/75 files checked 44% done
Checking src/tools/line/linetool.cpp ...
34/75 files checked 45% done
Checking src/tools/marker/markertool.cpp ...
35/75 files checked 46% done
Checking src/tools/move/movetool.cpp ...
36/75 files checked 48% done
Checking src/tools/pencil/penciltool.cpp ...
37/75 files checked 49% done
Checking src/tools/pin/pintool.cpp ...
Checking src/tools/pin/pintool.cpp: Q_OS_LINUX;Q_OS_UNIX...
38/75 files checked 50% done
Checking src/tools/pin/pinwidget.cpp ...
39/75 files checked 52% done
Checking src/tools/rectangle/rectangletool.cpp ...
40/75 files checked 53% done
Checking src/tools/redo/redotool.cpp ...
41/75 files checked 54% done
Checking src/tools/save/savetool.cpp ...
42/75 files checked 56% done
Checking src/tools/selection/selectiontool.cpp ...
43/75 files checked 57% done
Checking src/tools/sizeindicator/sizeindicatortool.cpp ...
44/75 files checked 58% done
Checking src/tools/text/textconfig.cpp ...
45/75 files checked 60% done
Checking src/tools/text/texttool.cpp ...
46/75 files checked 61% done
Checking src/tools/text/textwidget.cpp ...
47/75 files checked 62% done
Checking src/tools/toolfactory.cpp ...
48/75 files checked 64% done
Checking src/tools/undo/undotool.cpp ...
49/75 files checked 65% done
Checking src/utils/colorutils.cpp ...
50/75 files checked 66% done
Checking src/utils/confighandler.cpp ...
[src/utils/confighandler.cpp:241] -> [src/utils/confighandler.h:64]: (performance, inconclusive) Technically the member function 'ConfigHandler::startupLaunchValue' can be static.
[src/utils/confighandler.cpp:256] -> [src/utils/confighandler.h:65]: (performance, inconclusive) Technically the member function 'ConfigHandler::setStartupLaunch' can be static.
[src/utils/confighandler.cpp:315] -> [src/utils/confighandler.h:78]: (performance, inconclusive) Technically the member function 'ConfigHandler::normalizeButtons' can be static.
[src/utils/confighandler.cpp:331] -> [src/utils/confighandler.h:80]: (performance, inconclusive) Technically the member function 'ConfigHandler::fromIntToButton' can be static.
[src/utils/confighandler.cpp:340] -> [src/utils/confighandler.h:81]: (performance, inconclusive) Technically the member function 'ConfigHandler::fromButtonToInt' can be static.
Checking src/utils/confighandler.cpp: Q_OS_LINUX;Q_OS_UNIX...
[src/utils/confighandler.cpp:242] -> [src/utils/confighandler.cpp:245]: (style) Variable 'res' is reassigned a value before the old one has been used.
Checking src/utils/confighandler.cpp: Q_OS_WIN...
[src/utils/confighandler.cpp:242] -> [src/utils/confighandler.cpp:250]: (style) Variable 'res' is reassigned a value before the old one has been used.
51/75 files checked 68% done
Checking src/utils/dbusutils.cpp ...
[src/utils/dbusutils.h:30] -> [src/utils/dbusutils.cpp:41]: (style, inconclusive) Function 'checkDBusConnection' argument 1 names different: declaration 'connection' definition 'c'.
52/75 files checked 69% done
Checking src/utils/desktopfileparse.cpp ...
[src/utils/desktopfileparse.cpp:130] -> [src/utils/desktopfileparse.h:60]: (style, inconclusive) Technically the member function 'DesktopFileParser::getAppsByCategory' can be const.
[src/utils/desktopfileparse.cpp:140] -> [src/utils/desktopfileparse.h:61]: (style, inconclusive) Technically the member function 'DesktopFileParser::getAppsByCategory' can be const.
[src/utils/desktopfileparse.h:32]: (performance, inconclusive) Function parameter 'name' should be passed by const reference.
[src/utils/desktopfileparse.h:33]: (performance, inconclusive) Function parameter 'description' should be passed by const reference.
[src/utils/desktopfileparse.h:34]: (performance, inconclusive) Function parameter 'exec' should be passed by const reference.
53/75 files checked 70% done
Checking src/utils/desktopinfo.cpp ...
54/75 files checked 72% done
Checking src/utils/filenamehandler.cpp ...
55/75 files checked 73% done
Checking src/utils/globalvalues.cpp ...
56/75 files checked 74% done
Checking src/utils/pathinfo.cpp ...
Checking src/utils/pathinfo.cpp: Q_OS_LINUX;Q_OS_UNIX...
Checking src/utils/pathinfo.cpp: Q_OS_WIN...
57/75 files checked 76% done
Checking src/utils/screengrabber.cpp ...
Checking src/utils/screengrabber.cpp: Q_OS_LINUX;Q_OS_UNIX...
Checking src/utils/screengrabber.cpp: Q_OS_WIN...
58/75 files checked 77% done
Checking src/utils/screenshotsaver.cpp ...
[src/utils/screenshotsaver.cpp:31] -> [src/utils/screenshotsaver.h:27]: (performance, inconclusive) Technically the member function 'ScreenshotSaver::saveToClipboard' can be static.
[src/utils/screenshotsaver.cpp:37] -> [src/utils/screenshotsaver.h:28]: (performance, inconclusive) Technically the member function 'ScreenshotSaver::saveToFilesystem' can be static.
[src/utils/screenshotsaver.cpp:56] -> [src/utils/screenshotsaver.h:29]: (performance, inconclusive) Technically the member function 'ScreenshotSaver::saveToFilesystemGUI' can be static.
59/75 files checked 78% done
Checking src/utils/systemnotification.cpp ...
[src/utils/systemnotification.cpp:22]: (warning) Member variable 'SystemNotification::m_interface' is not initialized in the constructor.
Checking src/utils/systemnotification.cpp: Q_OS_LINUX;Q_OS_UNIX...
Checking src/utils/systemnotification.cpp: Q_OS_WIN...
60/75 files checked 80% done
Checking src/utils/waylandutils.cpp ...
61/75 files checked 81% done
Checking src/widgets/capture/buttonhandler.cpp ...
62/75 files checked 82% done
Checking src/widgets/capture/capturebutton.cpp ...
63/75 files checked 84% done
Checking src/widgets/capture/capturewidget.cpp ...
[src/widgets/capture/capturewidget.h:55] -> [src/widgets/capture/capturewidget.cpp:52]: (style, inconclusive) Function 'CaptureWidget' argument 3 names different: declaration 'fullScreen' definition 'fullscreen'.
Checking src/widgets/capture/capturewidget.cpp: Q_OS_WIN...
64/75 files checked 85% done
Checking src/widgets/capture/colorpicker.cpp ...
65/75 files checked 86% done
Checking src/widgets/capture/hovereventfilter.cpp ...
66/75 files checked 88% done
Checking src/widgets/capture/modificationcommand.cpp ...
67/75 files checked 89% done
Checking src/widgets/capture/notifierbox.cpp ...
68/75 files checked 90% done
Checking src/widgets/capture/selectionwidget.cpp ...
[src/widgets/capture/selectionwidget.h:42] -> [src/widgets/capture/selectionwidget.cpp:45]: (style, inconclusive) Function 'getMouseSide' argument 1 names different: declaration 'p' definition 'point'.
69/75 files checked 92% done
Checking src/widgets/imagelabel.cpp ...
70/75 files checked 93% done
Checking src/widgets/infowindow.cpp ...
71/75 files checked 94% done
Checking src/widgets/loadspinner.cpp ...
72/75 files checked 96% done
Checking src/widgets/notificationwidget.cpp ...
73/75 files checked 97% done
Checking src/widgets/panel/colorpickerwidget.cpp ...
74/75 files checked 98% done
Checking src/widgets/panel/utilitypanel.cpp ...
75/75 files checked 100% done
[src/core/flameshotdbusadapter.cpp:89]: (style) The function 'autostartEnabled' is never used.
[src/core/flameshotdbusadapter.cpp:62]: (style) The function 'captureScreen' is never used.
[src/utils/filenamehandler.cpp:79]: (style) The function 'charArrToQString' is never used.
[src/widgets/capture/colorpicker.cpp:53]: (style) The function 'drawColor' is never used.
[src/tools/pin/pinwidget.cpp:72]: (style) The function 'enterEvent' is never used.
[src/widgets/capture/hovereventfilter.cpp:31]: (style) The function 'eventFilter' is never used.
[src/core/flameshotdbusadapter.cpp:48]: (style) The function 'fullScreen' is never used.
[src/core/flameshotdbusadapter.cpp:39]: (style) The function 'graphicCapture' is never used.
[src/cli/commandargument.cpp:47]: (style) The function 'isRoot' is never used.
[src/config/configwindow.cpp:84]: (style) The function 'keyPressEvent' is never used.
[src/tools/pin/pinwidget.cpp:75]: (style) The function 'leaveEvent' is never used.
[src/tools/pin/pinwidget.cpp:79]: (style) The function 'mouseDoubleClickEvent' is never used.
[src/tools/pin/pinwidget.cpp:89]: (style) The function 'mouseMoveEvent' is never used.
[src/config/clickablelabel.cpp:28]: (style) The function 'mousePressEvent' is never used.
[src/widgets/capture/capturewidget.cpp:423]: (style) The function 'mouseReleaseEvent' is never used.
[src/tools/arrow/arrowtool.cpp:83]: (style) The function 'nameID' is never used.
[src/core/globalshortcutfilter.cpp:31]: (style) The function 'nativeEventFilter' is never used.
[src/core/flameshotdbusadapter.cpp:76]: (style) The function 'openConfig' is never used.
[src/tools/launcher/launcheritemdelegate.cpp:27]: (style) The function 'paint' is never used.
[src/widgets/capture/capturewidget.cpp:198]: (style) The function 'paintEvent' is never used.
[src/tools/text/textwidget.cpp:57]: (style) The function 'setFontPointSize' is never used.
[src/cli/commandargument.cpp:31]: (style) The function 'setName' is never used.
[src/cli/commandoption.cpp:43]: (style) The function 'setNames' is never used.
[src/utils/confighandler.cpp:106]: (style) The function 'setUserColors' is never used.
[src/cli/commandoption.cpp:63]: (style) The function 'setValueName' is never used.
[src/widgets/capture/notifierbox.cpp:64]: (style) The function 'showColor' is never used.
[src/tools/launcher/openwithprogram.cpp:33]: (style) The function 'showOpenWithMenu' is never used.
[src/tools/launcher/launcheritemdelegate.cpp:58]: (style) The function 'sizeHint' is never used.
[src/core/flameshotdbusadapter.cpp:80]: (style) The function 'trayIconEnabled' is never used.
[src/tools/text/textwidget.cpp:53]: (style) The function 'updateFont' is never used.
[src/utils/waylandutils.cpp:8]: (style) The function 'waylandDetected' is never used.
[src/tools/pin/pinwidget.cpp:60]: (style) The function 'wheelEvent' is never used.
(information) Cppcheck cannot find all the include files (use --check-config for details)
```

</details>

**Issues fixed**:

- [x] [src/core/capturerequest.h:68]
- [x] [src/core/capturerequest.h:68]
- [x] [src/core/capturerequest.h:72]
- [x] [src/core/capturerequest.h:72]
- [x] [src/core/capturerequest.h:76]
- [x] [src/tools/capturetool.h:71] -> [src/tools/abstractactiontool.h:27]
- [x] [src/tools/capturetool.h:71] -> [src/tools/abstractpathtool.h:27]
- [x] [src/tools/capturetool.h:74] -> [src/tools/abstractpathtool.h:28]
- [x] [src/tools/capturetool.h:71] -> [src/tools/abstracttwopointtool.h:27]
- [x] [src/tools/capturetool.h:74] -> [src/tools/abstracttwopointtool.h:28]
- [x] [src/tools/imgur/imguruploader.h:36] -> [src/tools/imgur/imguruploader.cpp:44]
- [x] [src/utils/dbusutils.h:30] -> [src/utils/dbusutils.cpp:41]
- [x] [src/utils/desktopfileparse.h:32]
- [x] [src/utils/desktopfileparse.h:33]
- [x] [src/utils/desktopfileparse.h:34]
- [x] [src/utils/systemnotification.cpp:22]
- [x] [src/widgets/capture/capturewidget.h:55] -> [src/widgets/capture/capturewidget.cpp:52]
- [x] [src/widgets/capture/selectionwidget.h:42] -> [src/widgets/capture/selectionwidget.cpp:45]
- [x] [src/core/flameshotdbusadapter.cpp:48]