### PR TITLE
Remove unneeded BASEDIR variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,11 +203,11 @@ Having `git` installed is required if you want to have  precise app version info
 
 In order to generate the makefile installing in `/usr` instead of in `/usr/local` you can use the `packaging` option to generate the proper makefile (`qmake CONFIG+=packaging` instead of just `qmake`).
 
-If you want to install in a custom directory you can define the `BASEDIR` variable.
+If you want to install in a custom directory you can use the `INSTALL_ROOT` variable.
 
 **Example**:
 You want to install Flameshot in ~/myBuilds/test. You would execute the following to do so:
-`qmake CONFIG+=packaging BASEDIR=~/myBuilds/test && make install`
+`qmake CONFIG+=packaging && make INSTALL_ROOT=~/myBuilds/test install`
 
 ### Runtime Dependencies
 

--- a/flameshot.pro
+++ b/flameshot.pro
@@ -241,27 +241,27 @@ unix:!macx {
 
     DEFINES += APP_PREFIX=\\\"$$PREFIX\\\"
 
-    target.path = $${BASEDIR}$${PREFIX}/bin/
+    target.path = $${PREFIX}/bin/
 
-    qmfile.path = $${BASEDIR}$${PREFIX}/share/flameshot/translations/
+    qmfile.path = $${PREFIX}/share/flameshot/translations/
     qmfile.files = $${TRANSLATIONS_FILES}
 
-    dbus.path = $${BASEDIR}$${PREFIX}/share/dbus-1/interfaces/
+    dbus.path = $${PREFIX}/share/dbus-1/interfaces/
     dbus.files = dbus/org.dharkael.Flameshot.xml
 
-    icon.path = $${BASEDIR}$${PREFIX}/share/icons/
+    icon.path = $${PREFIX}/share/icons/
     icon.files = img/app/flameshot.svg
 
-    completion.path = $${BASEDIR}$${PREFIX}/share/bash-completion/completions/
+    completion.path = $${PREFIX}/share/bash-completion/completions/
     completion.files = docs/bash-completion/flameshot
 
-    appdata.path = $${BASEDIR}$${PREFIX}/share/metainfo/
+    appdata.path = $${PREFIX}/share/metainfo/
     appdata.files = docs/appdata/flameshot.appdata.xml
 
-    desktopentry.path = $${BASEDIR}$${PREFIX}/share/applications
+    desktopentry.path = $${PREFIX}/share/applications
     desktopentry.files = docs/desktopEntry/package/flameshot.desktop
 
-    servicedbus.path = $${BASEDIR}$${PREFIX}/share/dbus-1/services/
+    servicedbus.path = $${PREFIX}/share/dbus-1/services/
 
     packaging {
         servicedbus.files = dbus/package/org.dharkael.Flameshot.service


### PR DESCRIPTION
`qmake` already generates a `INSTALL_ROOT` variable that can be used to install in a custom directory.

This should be merged after @simonbcn updates his `PKGBUILD`, otherwise it will break the package.

Fixes #291