### PR TITLE
Change icon path

### DIFF
--- a/flameshot.pro
+++ b/flameshot.pro
@@ -249,7 +249,7 @@ unix:!macx {
     dbus.path = $${PREFIX}/share/dbus-1/interfaces/
     dbus.files = dbus/org.dharkael.Flameshot.xml
 
-    icon.path = $${PREFIX}/share/icons/
+    icon.path = $${PREFIX}/share/pixmaps/
     icon.files = img/app/flameshot.svg
 
     completion.path = $${PREFIX}/share/bash-completion/completions/

--- a/rpm/flameshot.spec
+++ b/rpm/flameshot.spec
@@ -54,7 +54,7 @@ make %{?_smp_mflags}
 %{_datadir}/flameshot/translations/Internationalization_*.qm
 %{_datadir}/applications/%{name}.desktop
 %{_datadir}/bash-completion/completions/%{name}
-%{_datadir}/icons/%{name}.svg
+%{_datadir}/pixmaps/%{name}.svg
 
 %changelog
 * Tue Jan 09 2018 Zetao Yang <yangzetao2015@outlook.com> - 0.5.0-1


### PR DESCRIPTION
It now installs the image in any of the following paths, depending if `CONFIG+=packaging` was set in `qmake`.

- `/usr/local/share/pixmaps/`
- `/usr/share/pixmaps`