### PR TITLE
fix auto locale detection

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,7 +50,7 @@ int main(int argc, char *argv[]) {
         QStringList trPaths = PathInfo::translationsPaths();
 
         for (const QString &path: trPaths) {
-            bool match = translator.load(QLocale::system().language(),
+            bool match = translator.load(QLocale(),
                                     "Internationalization", "_",
                                     path);
             if (match) {


### PR DESCRIPTION
In current implementation QLocale::system.language() will not correctly
differs Simplified Chinese with Traditional Chinese, which is causing
problems to load translations for zh_TW when both are availabe.
This patch fix the problem by using default ctor QLocale() following
the documentation here:
https://doc.qt.io/qt-5/qtranslator.html#load-1