### PR TITLE
Minor fix for appdata project license metadata

### DIFF
--- a/docs/appdata/flameshot.appdata.xml
+++ b/docs/appdata/flameshot.appdata.xml
@@ -3,7 +3,7 @@
 <component type="desktop">
   <id>flameshot.desktop</id>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>GPLv3+ and ASL 2.0 and GPLv2 and LGPLv3 and Free Art</project_license>
+  <project_license>GPL-3.0-or-later and ASL 2.0 and GPLv2 and LGPLv3 and Free Art</project_license>
   <name>Flameshot</name>
   <summary>Powerful and simple to use screenshot software</summary>
   <description>


### PR DESCRIPTION
From https://appstream.debian.org/sid/main/issues/flameshot.html :
    
    * metainfo-validation-issue
    Validation of the metainfo file found a problem:
    SPDX license ID 'GPLv3+' is unknown.
    
According to https://spdx.org/licenses/ , the correct identifier for GPLv3+ is "GPL-3.0-or-later" now. This PR would make that replacement.

P.S. Other licenses mentioned in the `project_license` line seem also bogus. If you have any idea and if they are listed in https://spdx.org/licenses/ , please consider using the canonical Identifier too.