### PR TITLE
Put infowindow to screen center when available

### DIFF
--- a/src/widgets/infowindow.cpp
+++ b/src/widgets/infowindow.cpp
@@ -23,12 +23,26 @@
 #include <QLabel>
 #include <QKeyEvent>
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+#include <QCursor>
+#include <QRect>
+#include <QScreen>
+#include <QGuiApplication>
+#endif
+
 // InfoWindow show basic information about the usage of Flameshot
 
 InfoWindow::InfoWindow(QWidget *parent) : QWidget(parent) {
     setAttribute(Qt::WA_DeleteOnClose);
     setWindowIcon(QIcon(":img/app/flameshot.svg"));
     setWindowTitle(tr("About"));
+
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+    QRect position = frameGeometry();
+    QScreen *screen = QGuiApplication::screenAt(QCursor::pos());
+    position.moveCenter(screen->availableGeometry().center());
+    move(position.topLeft());
+#endif
 
     m_layout = new QVBoxLayout(this);
     m_layout->setAlignment(Qt::AlignHCenter);


### PR DESCRIPTION
Currently info window will always pop up at the topleft corner of the screen, which is rather bothering. This patch will move the window to screen center when popped up.

Since [`QGuiApplication::ScreenAt()`](https://doc.qt.io/qt-5/qguiapplication.html#screenAt) is introduced since Qt 5.10, the
code will only take effect when compiled against Qt >= 5.10.

(I'm not really willing to use [`QDesktopWidget`](https://doc.qt.io/qt-5/qdesktopwidget.html) since the whole class is declared as obsoleted already.)