### PR TITLE
Some adjustment for Pin Tool

### DIFF
--- a/src/tools/pin/pintool.cpp
+++ b/src/tools/pin/pintool.cpp
@@ -45,11 +45,7 @@ QString PinTool::description() const {
 QWidget* PinTool::widget() {
     PinWidget *w = new PinWidget(m_pixmap);
     const int &&m = w->margin();
-#if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
-    QRect adjusted_pos = m_geometry + QMargins(m,-m,-m,-m);
-#else
     QRect adjusted_pos = m_geometry + QMargins(m, m, m, m);
-#endif
     w->setGeometry(adjusted_pos);
     return w;
 }

--- a/src/tools/pin/pinwidget.cpp
+++ b/src/tools/pin/pinwidget.cpp
@@ -27,7 +27,8 @@ PinWidget::PinWidget(const QPixmap &pixmap, QWidget *parent) :
     QWidget(parent), m_pixmap(pixmap)
 {
     setWindowFlags(Qt::WindowStaysOnTopHint
-                   | Qt::FramelessWindowHint);
+                   | Qt::FramelessWindowHint
+                   | Qt::X11BypassWindowManagerHint);
     //set the bottom widget background transparent
     setAttribute(Qt::WA_TranslucentBackground);
 
@@ -58,7 +59,7 @@ int PinWidget::margin() const {
 }
 
 void PinWidget::wheelEvent(QWheelEvent *e) {
-    int val = e->delta() > 0 ? 5 : -5;
+    int val = e->delta() > 0 ? 15 : -15;
     int newWidth = qBound(50, m_label->width() + val, maximumWidth());
     int newHeight = qBound(50, m_label->height() + val, maximumHeight());
 

--- a/src/tools/pin/pinwidget.cpp
+++ b/src/tools/pin/pinwidget.cpp
@@ -27,8 +27,7 @@ PinWidget::PinWidget(const QPixmap &pixmap, QWidget *parent) :
     QWidget(parent), m_pixmap(pixmap)
 {
     setWindowFlags(Qt::WindowStaysOnTopHint
-                   | Qt::FramelessWindowHint
-                   | Qt::X11BypassWindowManagerHint);
+                   | Qt::FramelessWindowHint);
     //set the bottom widget background transparent
     setAttribute(Qt::WA_TranslucentBackground);
 


### PR DESCRIPTION
- Change `adjusted_pos`, pin pictures to their original position. issue #350 
- Change the mouse wheel scroll delta, because `5` is too small, I have to scroll much times before I can adjust the pinned picture to the size that I want.
- Add `Qt::X11BypassWindowManagerHint` again.

All of above was tested normally, on **Fedora 28, Gnome 3.28.x, Qt 5.11.1**.