### PR TITLE
Fixes #362

### DIFF
--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -741,6 +741,7 @@ void CaptureWidget::initShortcuts() {
     new QShortcut(Qt::Key_Space, this, SLOT(togglePanel()));
     new QShortcut(Qt::Key_Escape, this, SLOT(deleteToolwidgetOrClose()));
     new QShortcut(Qt::Key_Return, this, SLOT(copyScreenshot()));
+    new QShortcut(Qt::Key_Enter, this, SLOT(copyScreenshot()));
 }
 
 void CaptureWidget::updateSizeIndicator() {


### PR DESCRIPTION
This fixes #362, making the enter key copy the content of the GUI selection copy the content to the clipboard