### PR TITLE
[WIP] Add Imgur OAuth2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ flameshot*.tar.bz2
 
 
 # End of https://www.gitignore.io/api/snapcraft
+
+build/

--- a/flameshot.pro
+++ b/flameshot.pro
@@ -141,7 +141,9 @@ SOURCES += src/main.cpp \
     src/tools/text/textwidget.cpp \
     src/core/capturerequest.cpp \
     src/tools/text/textconfig.cpp \
-    src/widgets/panel/sidepanelwidget.cpp
+    src/widgets/panel/sidepanelwidget.cpp \
+    src/config/imgurconf.cpp \
+    src/utils/imgurconfighandler.cpp
 
 HEADERS  += src/widgets/capture/buttonhandler.h \
     src/widgets/infowindow.h \
@@ -213,7 +215,9 @@ HEADERS  += src/widgets/capture/buttonhandler.h \
     src/tools/text/textwidget.h \
     src/core/capturerequest.h \
     src/tools/text/textconfig.h \
-    src/widgets/panel/sidepanelwidget.h
+    src/widgets/panel/sidepanelwidget.h \
+    src/config/imgurconf.h \
+    src/utils/imgurconfighandler.h
 
 unix:!macx {
     SOURCES += src/core/flameshotdbusadapter.cpp \

--- a/src/config/configwindow.cpp
+++ b/src/config/configwindow.cpp
@@ -25,6 +25,7 @@
 #include "src/config/strftimechooserwidget.h"
 #include "src/config/visualseditor.h"
 #include "src/utils/globalvalues.h"
+#include "src/config/imgurconf.h"
 #include <QIcon>
 #include <QVBoxLayout>
 #include <QLabel>
@@ -71,6 +72,11 @@ ConfigWindow::ConfigWindow(QWidget *parent) : QTabWidget(parent) {
     m_generalConfig = new GeneneralConf();
     addTab(m_generalConfig, QIcon(modifier + "config.svg"),
            tr("General"));
+
+    // imgur
+    m_imgurConfig = new ImgurConf();
+    addTab(m_imgurConfig, QIcon(modifier + "cloud-upload.svg"),
+           tr("Imgur"));
 
     // connect update sigslots
     connect(this, &ConfigWindow::updateChildren,

--- a/src/config/imgurconf.cpp
+++ b/src/config/imgurconf.cpp
@@ -1,0 +1,181 @@
+#include "imgurconf.h"
+
+ImgurConf::ImgurConf(QWidget *parent) : QWidget(parent)
+{
+    initWidgets();
+    updateComponents();
+}
+
+void ImgurConf::authorize()
+{
+    if (config.isAuthorized()) {
+        return;
+    }
+
+    QString clientId = config.getSetting(QStringLiteral("Api/client_id"), "").toString();
+    QString clientSecret = config.getSetting(QStringLiteral("Api/client_secret"), "").toString();
+
+    if (clientId.isEmpty() || clientSecret.isEmpty()) {
+        return;
+    }
+
+    QUrlQuery urlQuery;
+    urlQuery.addQueryItem(QStringLiteral("client_id"), clientId);
+    urlQuery.addQueryItem(QStringLiteral("response_type"), QStringLiteral("token"));
+
+    QUrl url(QStringLiteral("https://api.imgur.com/oauth2/authorize"));
+    url.setQuery(urlQuery);
+
+    // Authorization URL
+    QDesktopServices::openUrl(url);
+
+    // Authorization response
+    QString token_url = QInputDialog::getText(this, tr("Imgur token"), tr("Token URL"));
+
+    // Generate Imgur token
+    extractToken(token_url);
+}
+
+void ImgurConf::deauthorize()
+{
+    if (!config.isAuthorized()) {
+        return;
+    }
+
+    int button = QMessageBox::warning(
+        this,
+        tr("Delete Imgur data"),
+        tr("This will delete all Imgur data including API credentials and authentication token. You won't be able to recover said data so please be certain.<br><br>Are you sure you want to delete all Imgur data?"),
+        QMessageBox::Yes|QMessageBox::No,
+        QMessageBox::No
+    );
+
+    if (button != QMessageBox::Yes) {
+        return;
+    }
+
+    m_clientIdField->setText(QLatin1String(""));
+    m_clientSecretField->setText(QLatin1String(""));
+    m_albumField->setText(QLatin1String(""));
+    m_anonymousUpload->setChecked(false);
+
+    updateImgurSettings();
+    emit settingsChanged();
+}
+
+void ImgurConf::updateImgurSettings()
+{
+    QMap<QString, QVariant> token = config.getToken();
+
+    // Check for API changes
+    if (m_clientIdField->text() != config.getSetting(QStringLiteral("Api/client_id")).toString() ||
+        m_clientSecretField->text() != config.getSetting(QStringLiteral("Api/client_secret")).toString()) {
+        // Purge old token
+        QMap<QString, QVariant> emptyToken = {};
+        config.setToken(emptyToken);
+    }
+
+    config.setApiCredentials(m_clientIdField->text(), m_clientSecretField->text());
+    config.setSetting(QStringLiteral("album"), m_albumField->text());
+    config.setSetting(QStringLiteral("anonymous_upload"), config.isAuthorized() && m_anonymousUpload->isChecked());
+
+    emit settingsChanged();
+}
+
+void ImgurConf::updateComponents()
+{
+    QMap<QString, QVariant> token = config.getToken();
+
+    m_clientIdField->setText(config.getSetting(QStringLiteral("Api/client_id")).toString());
+    m_clientSecretField->setText(config.getSetting(QStringLiteral("Api/client_secret")).toString());
+    m_userField->setText(token.value(QStringLiteral("account_username")).toString());
+    m_albumField->setText(config.getSetting(QStringLiteral("album")).toString());
+    m_anonymousUpload->setChecked(config.getSetting(QStringLiteral("anonymous_upload")).toBool());
+
+    m_logInButton->setEnabled(false);
+    m_logOutButton->setEnabled(true);
+
+    if (token.isEmpty()) {
+        m_logInButton->setEnabled(true);
+        m_logOutButton->setEnabled(false);
+    }
+}
+
+void ImgurConf::initWidgets()
+{
+    m_widgetLayout = new QVBoxLayout(this);
+
+    QGroupBox *imgurApi = new QGroupBox(tr("Imgur API"), this);
+    QFormLayout *imgurApiLayout = new QFormLayout(imgurApi);
+    m_clientIdField = new QLineEdit(imgurApi);
+    m_clientSecretField = new QLineEdit(imgurApi);
+    m_clientSecretField->setEchoMode(QLineEdit::PasswordEchoOnEdit);
+    imgurApiLayout->addRow(tr("Client ID"), m_clientIdField);
+    imgurApiLayout->addRow(tr("Client Secret"), m_clientSecretField);
+    imgurApiLayout->itemAt(1, QFormLayout::FieldRole)->widget();
+    imgurApi->setLayout(imgurApiLayout);
+    m_widgetLayout->addWidget(imgurApi);
+
+    QGroupBox *imgurAccount = new QGroupBox(tr("Imgur Account"), this);
+    QFormLayout *imgurAccountLayout = new QFormLayout(imgurAccount);
+    m_userField = new QLabel(tr("N/A"), imgurAccount);
+    m_userField->setStyleSheet(QStringLiteral("font-weight: bold"));
+    m_albumField = new QLineEdit(imgurAccount);
+    m_anonymousUpload = new QCheckBox(tr("Anonymous upload"), imgurAccount);
+    m_anonymousUpload->setToolTip(tr("This will use your Imgur client ID but it won't be uploaded to your account."));
+    imgurAccountLayout->addRow(tr("User"), m_userField);
+    imgurAccountLayout->addRow(tr("Album"), m_albumField);
+    imgurAccountLayout->addWidget(m_anonymousUpload);
+    imgurAccount->setLayout(imgurAccountLayout);
+    m_widgetLayout->addWidget(imgurAccount);
+
+    m_widgetLayout->addStretch();
+    QGroupBox *actionButtons = new QGroupBox(QStringLiteral("Actions"), this);
+    QHBoxLayout *buttonLayout = new QHBoxLayout(actionButtons);
+    m_logInButton = new QPushButton(tr("Login"), actionButtons);
+    m_logOutButton = new QPushButton(tr("Logout"), actionButtons);
+    m_saveButton = new QPushButton(tr("Save"), actionButtons);
+    buttonLayout->addWidget(m_logInButton);
+    buttonLayout->addWidget(m_logOutButton);
+    buttonLayout->addWidget(m_saveButton);
+    actionButtons->setLayout(buttonLayout);
+    m_widgetLayout->addWidget(actionButtons);
+
+    connect(m_logInButton, &QPushButton::clicked, this, &ImgurConf::authorize);
+    connect(m_logOutButton, &QPushButton::clicked, this, &ImgurConf::deauthorize);
+    connect(m_saveButton, &QPushButton::clicked, this, &ImgurConf::updateImgurSettings);
+    connect(this, &ImgurConf::settingsChanged, this, &ImgurConf::updateComponents);
+}
+
+void ImgurConf::extractToken(QString &token_url)
+{
+    if (token_url.isEmpty() || token_url.isNull()) {
+        return;
+    }
+
+    // Remove unneeded data
+    token_url.remove(QRegularExpression(QStringLiteral("^.+#")));
+
+    QUrlQuery urlQuery(token_url);
+
+    QMap<QString, QVariant> token;
+
+    for (const QPair<QString, QString> &pair : urlQuery.queryItems()) {
+        // Filter token
+        if (pair.first != QLatin1String("access_token") &&
+            pair.first != QLatin1String("expires_in") &&
+            pair.first != QLatin1String("token_type") &&
+            pair.first != QLatin1String("refresh_token") &&
+            pair.first != QLatin1String("account_username") &&
+            pair.first != QLatin1String("account_id")) {
+            continue;
+        }
+
+        // Generate token
+        token.insert(pair.first, pair.second);
+    }
+
+    config.setToken(token);
+
+    emit settingsChanged();
+}

--- a/src/config/imgurconf.h
+++ b/src/config/imgurconf.h
@@ -1,0 +1,77 @@
+// Copyright(c) 2017-2018 Alejandro Sirgo Rica & Contributors
+//
+// This file is part of Flameshot.
+//
+//     Flameshot is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     Flameshot is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License
+//     along with Flameshot.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <QWidget>
+#include <QMessageBox>
+#include <QInputDialog>
+#include <QDesktopServices>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QFormLayout>
+#include <QGroupBox>
+#include <QLabel>
+#include <QLineEdit>
+#include <QCheckBox>
+#include <QPushButton>
+#include <QVariant>
+#include <QNetworkAccessManager>
+#include <QNetworkRequest>
+#include <QNetworkReply>
+#include <QUrl>
+#include <QUrlQuery>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QRegularExpression>
+#include <QMap>
+#include <QList>
+#include <QPair>
+
+#include "src/utils/imgurconfighandler.h"
+
+class ImgurConf : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit ImgurConf(QWidget *parent = nullptr);
+
+signals:
+    void settingsChanged();
+
+public slots:
+    void authorize();
+    void deauthorize();
+    void updateImgurSettings();
+    void updateComponents();
+
+private:
+    ImgurConfigHandler config;
+    QNetworkAccessManager *m_networkManager;
+    QVBoxLayout *m_widgetLayout;
+    QLabel *m_userField;
+    QLineEdit *m_albumField;
+    QCheckBox *m_anonymousUpload;
+    QLineEdit *m_clientIdField;
+    QLineEdit *m_clientSecretField;
+    QPushButton *m_logInButton;
+    QPushButton *m_logOutButton;
+    QPushButton *m_saveButton;
+
+    void initWidgets();
+    void extractToken(QString &token_url);
+};

--- a/src/config/imgurconf.h
+++ b/src/config/imgurconf.h
@@ -54,10 +54,12 @@ signals:
     void settingsChanged();
 
 public slots:
-    void authorize();
+    void authorize(bool force = false);
     void deauthorize();
-    void updateImgurSettings();
-    void updateComponents();
+    void refreshToken();
+
+private slots:
+    void handleReply(QNetworkReply *reply);
 
 private:
     ImgurConfigHandler config;
@@ -73,5 +75,7 @@ private:
     QPushButton *m_saveButton;
 
     void initWidgets();
+    void updateImgurSettings();
+    void updateComponents();
     void extractToken(QString &token_url);
 };

--- a/src/tools/imgur/imguruploader.cpp
+++ b/src/tools/imgur/imguruploader.cpp
@@ -96,7 +96,11 @@ void ImgurUploader::handleReply(QNetworkReply *reply) {
 
             case 429: // Rate limit
                 QDateTime wait;
+#if QT_VERSION < QT_VERSION_CHECK(5, 8, 0)
+                wait.setTime_t(reply->rawHeader("X-RateLimit-UserReset").toInt());
+#else
                 wait.setSecsSinceEpoch(reply->rawHeader("X-RateLimit-UserReset").toInt());
+#endif
                 m_infoLabel->setText(
                     tr("API rate limit reached, you'll need to wait %1 seconds to try again.")
                         .arg(QDateTime::currentDateTimeUtc().secsTo(wait))

--- a/src/tools/imgur/imguruploader.cpp
+++ b/src/tools/imgur/imguruploader.cpp
@@ -71,6 +71,7 @@ ImgurUploader::ImgurUploader(const QPixmap &capture, QWidget *parent) :
 
 void ImgurUploader::handleReply(QNetworkReply *reply) {
     m_spinner->deleteLater();
+
     if (reply->error() == QNetworkReply::NoError) {
         QJsonDocument response = QJsonDocument::fromJson(reply->readAll());
         QJsonObject json = response.object();
@@ -81,7 +82,29 @@ void ImgurUploader::handleReply(QNetworkReply *reply) {
         onUploadOk();
     } else {
         m_infoLabel->setText(reply->errorString());
+        int status = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+        ImgurConf *imgurConfWidget = new ImgurConf(this);
+
+        switch(status) {
+            case 401: // Probably unauthorized
+                emit imgurConfWidget->authorize(true);
+            break;
+
+            case 403: // Probably invalid token
+                emit imgurConfWidget->refreshToken();
+            break;
+
+            case 429: // Rate limit
+                QDateTime wait;
+                wait.setSecsSinceEpoch(reply->rawHeader("X-RateLimit-UserReset").toInt());
+                m_infoLabel->setText(
+                    tr("API rate limit reached, you'll need to wait %1 seconds to try again.")
+                        .arg(QDateTime::currentDateTimeUtc().secsTo(wait))
+                );
+            break;
+        }
     }
+
     new QShortcut(Qt::Key_Escape, this, SLOT(close()));
 }
 
@@ -123,8 +146,10 @@ void ImgurUploader::upload() {
     QByteArray authorization = QStringLiteral("Client-ID %1").arg(IMGUR_CLIENT_ID).toUtf8();
 
     if (config.isAuthorized() && config.getSetting(QStringLiteral("anonymous_upload")).toBool()) {
+        // Anonymous upload of authorized application
         authorization = QStringLiteral("Client-ID %1").arg(config.getSetting(QStringLiteral("Api/client_id"), "").toString()).toUtf8();
     } else if (config.isAuthorized()) {
+        // Upload image to user account
         authorization = QStringLiteral("Bearer %1").arg(token.value(QStringLiteral("access_token"), "").toString()).toUtf8();
     }
 

--- a/src/tools/imgur/imguruploader.h
+++ b/src/tools/imgur/imguruploader.h
@@ -20,6 +20,8 @@
 #include <QWidget>
 #include <QUrl>
 
+#include "src/utils/imgurconfighandler.h"
+
 class QNetworkReply;
 class QNetworkAccessManager;
 class QHBoxLayout;

--- a/src/tools/imgur/imguruploader.h
+++ b/src/tools/imgur/imguruploader.h
@@ -21,6 +21,7 @@
 #include <QUrl>
 
 #include "src/utils/imgurconfighandler.h"
+#include "src/config/imgurconf.h"
 
 class QNetworkReply;
 class QNetworkAccessManager;

--- a/src/utils/imgurconfighandler.cpp
+++ b/src/utils/imgurconfighandler.cpp
@@ -1,0 +1,69 @@
+#include "imgurconfighandler.h"
+
+ImgurConfigHandler::ImgurConfigHandler()
+{
+    m_imgurConfig = new QSettings(
+        QSettings::IniFormat,
+        QSettings::UserScope,
+        qApp->organizationName(),
+        QStringLiteral("imgur")
+    );
+}
+
+bool ImgurConfigHandler::isAuthorized() const
+{
+    if (!m_imgurConfig->value(QStringLiteral("Api/client_id")).toString().isEmpty() &&
+        !m_imgurConfig->value(QStringLiteral("Api/client_secret")).toString().isEmpty() &&
+        !getToken().isEmpty()) {
+        return true;
+    }
+
+    return false;
+}
+
+QMap<QString, QVariant> ImgurConfigHandler::getToken() const
+{
+    if (m_imgurConfig->value(QStringLiteral("Token/access_token")).toString().isEmpty() ||
+        m_imgurConfig->value(QStringLiteral("Token/expires_in")).toInt() <= 0 ||
+        m_imgurConfig->value(QStringLiteral("Token/token_type")).toString().isEmpty() ||
+        m_imgurConfig->value(QStringLiteral("Token/refresh_token")).toString().isEmpty() ||
+        m_imgurConfig->value(QStringLiteral("Token/account_username")).toString().isEmpty() ||
+        m_imgurConfig->value(QStringLiteral("Token/account_id")).toInt() <= 0) {
+        return {};
+    }
+
+    return QMap<QString, QVariant> {
+        {"access_token", m_imgurConfig->value("Token/access_token").toString()},
+        {"expires_in", m_imgurConfig->value("Token/expires_in").toInt()},
+        {"token_type", m_imgurConfig->value("Token/token_type").toString()},
+        {"refresh_token", m_imgurConfig->value("Token/refresh_token").toString()},
+        {"account_username", m_imgurConfig->value("Token/account_username").toString()},
+        {"account_id", m_imgurConfig->value("Token/account_id").toInt()}
+    };
+}
+
+void ImgurConfigHandler::setApiCredentials(const QString &clientId, const QString &clientSecret)
+{
+    m_imgurConfig->setValue(QStringLiteral("Api/client_id"), clientId);
+    m_imgurConfig->setValue(QStringLiteral("Api/client_secret"), clientSecret);
+}
+
+void ImgurConfigHandler::setToken(QMap<QString, QVariant> &token)
+{
+    m_imgurConfig->setValue(QStringLiteral("Token/access_token"), token.value(QStringLiteral("access_token")).toString());
+    m_imgurConfig->setValue(QStringLiteral("Token/expires_in"), token.value(QStringLiteral("expires_in")).toInt());
+    m_imgurConfig->setValue(QStringLiteral("Token/token_type"), token.value(QStringLiteral("token_type")).toString());
+    m_imgurConfig->setValue(QStringLiteral("Token/refresh_token"), token.value(QStringLiteral("refresh_token")).toString());
+    m_imgurConfig->setValue(QStringLiteral("Token/account_username"), token.value(QStringLiteral("account_username")).toString());
+    m_imgurConfig->setValue(QStringLiteral("Token/account_id"), token.value(QStringLiteral("account_id")).toInt());
+}
+
+void ImgurConfigHandler::setSetting(const QString &key, const QVariant &value)
+{
+    m_imgurConfig->setValue(key, value);
+}
+
+QVariant ImgurConfigHandler::getSetting(const QString &key, const QVariant &defaultValue) const
+{
+    return m_imgurConfig->value(key, defaultValue);
+}

--- a/src/utils/imgurconfighandler.h
+++ b/src/utils/imgurconfighandler.h
@@ -17,29 +17,22 @@
 
 #pragma once
 
-#include <QTabWidget>
+#include <QApplication>
+#include <QSettings>
+#include <QMap>
+#include <QVariant>
 
-class FileNameEditor;
-class GeneneralConf;
-class QFileSystemWatcher;
-class VisualsEditor;
-class ImgurConf;
-
-class ConfigWindow : public QTabWidget {
-    Q_OBJECT
+class ImgurConfigHandler
+{
 public:
-    explicit ConfigWindow(QWidget *parent = nullptr);
-
-signals:
-    void updateChildren();
-
-protected:
-    void keyPressEvent(QKeyEvent *);
+    explicit ImgurConfigHandler();
+    bool isAuthorized() const;
+    QMap<QString, QVariant> getToken() const;
+    void setApiCredentials(const QString &clientId, const QString &clientSecret);
+    void setToken(QMap<QString, QVariant> &token);
+    void setSetting(const QString &key, const QVariant &value = QVariant());
+    QVariant getSetting(const QString &key, const QVariant &defaultValue = QVariant()) const;
 
 private:
-    FileNameEditor *m_filenameEditor;
-    GeneneralConf *m_generalConfig;
-    VisualsEditor *m_visuals;
-    QFileSystemWatcher *m_configWatcher;
-    ImgurConf *m_imgurConfig;
+    QSettings *m_imgurConfig;
 };


### PR DESCRIPTION
These changes will allow to upload images to an Imgur account.

**Note:** This is a work in progress, it's not ready for a production environment.

<details>
<summary>Preview</summary>

![Config](https://i.imgur.com/zOzgsjd.png)

</details>

Progress:

- [x] Add configuration tab to set API data (`client_id` and `client_secret`)
- [x] Save Imgur data in a separate settings file
- [x] Authorize the application to generate a token
- [x] Upload images to Imgur account
- [x] Upload image to a specified album (optional)
- [x] Upload images anonymously using the given `client_id` (tries to address #188)
- [ ] Handle network errors and API limits
- [ ] Split token generatiion logic from Imgur configuration into separate files
- [ ] Correct or a more elegant way to get Imgur token
- [ ] Start from scratch to use [Qt Network Authorization](https://doc.qt.io/qt-5/qtnetworkauth-index.html) module? (Qt >= 5.8)

It currently generates the token by opening a URL in a web browser where the user will need to authorize the application, then it will be redirected to another URL where the user will need to copy and paste, in a dialog within Flameshot, to finally generate the token that will allow the user to upload images to their own account.

I don't like that however when I tried to use a PIN, as I do on one of my PHP applications, the entry point always returned an HTTP 400 error, and [the docs](https://apidocs.imgur.com/) says:

> The `code` and `pin` response types have been deprecated and will soon no longer be supported.

This is far from being finished, I opened this to receive feedback since this is the first time I work with an API with Qt.

Closes #43 
Closes #159 
Closes #188 