### PR TITLE
Remove transfer.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,8 +72,8 @@ script:
 # - if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then source travis/osx_script.sh; fi
   - pwd && ls
 
-after_success:
-  - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then source travis/linux_after_success.sh; fi
+#after_success:
+#  - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then source travis/linux_after_success.sh; fi
 
 # deploy:
 #    # Deploy packages to Github Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,7 +62,7 @@ after_build:
     - if "%PLATFORM%" EQU "x86" (xcopy "openssl-utils.git\win32\*.dll" "distrib\flameshot")
     - cd distrib
     - 7z a flameshot_%flameshot_version%_win_%PLATFORM%.zip flameshot
-    - curl --upload-file ./flameshot_%flameshot_version%_win_%PLATFORM%.zip https://transfer.sh/flameshot_%flameshot_version%_win_%PLATFORM%.zip
+#    - curl --upload-file ./flameshot_%flameshot_version%_win_%PLATFORM%.zip https://transfer.sh/flameshot_%flameshot_version%_win_%PLATFORM%.zip
 
 
 # artifacts:


### PR DESCRIPTION
Transfer.sh is now discontinued, however it has only been commented out in case a similar service is used in a future.

Fixes #396