### PR TITLE
Exit non-zero when aborting with --raw.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -235,7 +235,7 @@ int main(int argc, char *argv[]) {
                              &QCoreApplication::quit);
             t.start();
             // wait
-            app.exec();
+            return app.exec();
         }
     }
     else if (parser.isSet(fullArgument)) { // FULL
@@ -282,7 +282,7 @@ int main(int argc, char *argv[]) {
                              &QCoreApplication::quit);
             t.start();
             // wait
-            app.exec();
+            return app.exec();
         }
     }
     else if (parser.isSet(screenArgument)) { // SCREEN
@@ -332,7 +332,7 @@ int main(int argc, char *argv[]) {
                              &QCoreApplication::quit);
             t.start();
             // wait
-            app.exec();
+            return app.exec();
         }
     }
     else if (parser.isSet(configArgument)) { // CONFIG

--- a/src/utils/dbusutils.cpp
+++ b/src/utils/dbusutils.cpp
@@ -41,7 +41,7 @@ void DBusUtils::connectPrintCapture(QDBusConnection &session, uint id) {
 void DBusUtils::checkDBusConnection(const QDBusConnection &connection) {
     if (!connection.isConnected()) {
         SystemNotification().sendMessage(tr("Unable to connect via DBus"));
-        qApp->exit();
+        qApp->exit(1);
     }
 }
 
@@ -58,6 +58,6 @@ void DBusUtils::captureTaken(uint id, QByteArray rawImage) {
 void DBusUtils::captureFailed(uint id) {
     if (m_id == id) {
         QTextStream(stdout) << "screenshot aborted\n";
-        qApp->exit();
+        qApp->exit(1);
     }
 }


### PR DESCRIPTION
This fixes #302. Note that I also added a non-zero exit status when DBus
fails to connect.