### PR TITLE
Add support for more images formats

### DIFF
--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -60,14 +60,11 @@ bool ScreenshotSaver::saveToFilesystemGUI(const QPixmap &capture) {
         QString savePath = QFileDialog::getSaveFileName(
                     nullptr,
                     QString(),
-                    FileNameHandler().absoluteSavePath() + ".png");
+                    FileNameHandler().absoluteSavePath() + ".png",
+					QLatin1String("Portable Network Graphic file (PNG) (*.png);;BMP file (*.bmp);;JPEG file (*.jpg)"));
 
         if (savePath.isNull()) {
             break;
-        }
-
-        if (!savePath.endsWith(QLatin1String(".png"))) {
-            savePath += QLatin1String(".png");
         }
 
         ok = capture.save(savePath);

--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -67,12 +67,12 @@ bool ScreenshotSaver::saveToFilesystemGUI(const QPixmap &capture) {
             break;
         }
 
-		if (!savePath.endsWith(QLatin1String(".png"), Qt::CaseInsensitive) &&
-			!savePath.endsWith(QLatin1String(".bmp"), Qt::CaseInsensitive) &&
-			!savePath.endsWith(QLatin1String(".jpg"), Qt::CaseInsensitive)) {
+	if (!savePath.endsWith(QLatin1String(".png"), Qt::CaseInsensitive) &&
+	    !savePath.endsWith(QLatin1String(".bmp"), Qt::CaseInsensitive) &&
+	    !savePath.endsWith(QLatin1String(".jpg"), Qt::CaseInsensitive)) {
 
-			savePath += QLatin1String(".png");
-		}
+	    savePath += QLatin1String(".png");
+	}
 
         ok = capture.save(savePath);
 

--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -67,6 +67,13 @@ bool ScreenshotSaver::saveToFilesystemGUI(const QPixmap &capture) {
             break;
         }
 
+		if (!savePath.endsWith(QLatin1String(".png"), Qt::CaseInsensitive) &&
+			!savePath.endsWith(QLatin1String(".bmp"), Qt::CaseInsensitive) &&
+			!savePath.endsWith(QLatin1String(".jpg"), Qt::CaseInsensitive)) {
+
+			savePath += QLatin1String(".png");
+		}
+
         ok = capture.save(savePath);
 
         if (ok) {


### PR DESCRIPTION
Now when user wants to save screenshot it is possible to save it not only as png but with support of several image formats.
Resolves [#431](https://github.com/lupoDharkael/flameshot/issues/431)