### PR TITLE
utils/confighandler.cpp: Enable Pin and Text tool by default

### DIFF
--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -54,7 +54,9 @@ QVector<CaptureButton::ButtonType> ConfigHandler::getButtons() {
                 << CaptureButton::TYPE_SAVE
                 << CaptureButton::TYPE_EXIT
                 << CaptureButton::TYPE_IMAGEUPLOADER
-                << CaptureButton::TYPE_OPEN_APP;
+                << CaptureButton::TYPE_OPEN_APP
+                << CaptureButton::TYPE_PIN
+                << CaptureButton::TYPE_TEXT;
     }
 
     using bt = CaptureButton::ButtonType;


### PR DESCRIPTION
This commit enables all the available tools by default so that users may use them out-of-box without bothering with modifying configuration.