### PR TITLE
Check if filename contains invalid characters

### DIFF
--- a/src/config/filenameeditor.cpp
+++ b/src/config/filenameeditor.cpp
@@ -27,7 +27,7 @@
 
 FileNameEditor::FileNameEditor(QWidget *parent) : QWidget(parent) {
     initWidgets();
-    initLayout();    
+    initLayout();
 }
 
 void FileNameEditor::initLayout() {
@@ -36,6 +36,7 @@ void FileNameEditor::initLayout() {
     infoLabel->setFixedHeight(20);
     m_layout->addWidget(infoLabel);
     m_layout->addWidget(m_helperButtons);
+    m_layout->addWidget(new QLabel(tr("Invalid characters will be replaced with underscores.")));
     m_layout->addWidget(new QLabel(tr("Edit:")));
     m_layout->addWidget(m_nameEditor);
     m_layout->addWidget(new QLabel(tr("Preview:")));

--- a/src/utils/filenamehandler.cpp
+++ b/src/utils/filenamehandler.cpp
@@ -52,9 +52,7 @@ QString FileNameHandler::parseFilename(const QString &name) {
     free(tempData);
 
     // replace invalid characters with underscores
-    if (res.contains(invalidCharacters)) {
-        res = res.replace(invalidCharacters, "_");
-    }
+    res = res.replace(invalidCharacters, "_");
 
     return res;
 }

--- a/src/utils/filenamehandler.cpp
+++ b/src/utils/filenamehandler.cpp
@@ -27,7 +27,7 @@ FileNameHandler::FileNameHandler(QObject *parent) : QObject(parent) {
 #ifdef Q_OS_WIN
     invalidCharacters = QRegularExpression("[<>:\"/\\\\|?*]+");
 #else //Q_OS_LINUX
-    invalidCharacters = QRegularExpression("[/]+");
+    invalidCharacters = QRegularExpression(QStringLiteral("[/]+"));
 #endif
 }
 
@@ -52,7 +52,7 @@ QString FileNameHandler::parseFilename(const QString &name) {
     free(tempData);
 
     // replace invalid characters with underscores
-    res = res.replace(invalidCharacters, "_");
+    res = res.replace(invalidCharacters, QLatin1String("_"));
 
     return res;
 }

--- a/src/utils/filenamehandler.h
+++ b/src/utils/filenamehandler.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <QObject>
+#include <QRegularExpression>
 
 class FileNameHandler : public QObject {
     Q_OBJECT
@@ -42,4 +43,5 @@ private:
     char * QStringTocharArr(const QString &s);
 
     void fixPath(QString &directory, QString &filename);
+    QRegularExpression invalidCharacters;
 };


### PR DESCRIPTION
Currently it only have conditions for Windows and Linux/Unix, checks are done though regular expressions in the filename and invalid characters are replaced with underscores in the filename pattern.

Fixes #409