### PR TITLE
Allow notification to be dragged and dropped

### DIFF
--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -49,7 +49,7 @@ bool ScreenshotSaver::saveToFilesystem(const QPixmap &capture,
         saveMessage = QObject::tr("Error trying to save as ") + completePath;
     }
 
-    SystemNotification().sendMessage(saveMessage);
+    SystemNotification().sendMessage(saveMessage, ok ? completePath : "");
     return ok;
 }
 
@@ -80,7 +80,7 @@ bool ScreenshotSaver::saveToFilesystemGUI(const QPixmap &capture) {
             QString pathNoFile = savePath.left(savePath.lastIndexOf(QLatin1String("/")));
             ConfigHandler().setSavePath(pathNoFile);
             QString msg = QObject::tr("Capture saved as ") + savePath;
-            SystemNotification().sendMessage(msg);
+            SystemNotification().sendMessage(msg, savePath);
         } else {
             QString msg = QObject::tr("Error trying to save as ") + savePath;
             QMessageBox saveErrBox(

--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -41,15 +41,17 @@ bool ScreenshotSaver::saveToFilesystem(const QPixmap &capture,
     completePath += QLatin1String(".png");
     bool ok = capture.save(completePath);
     QString saveMessage;
+    QString notificationPath = completePath;
 
     if (ok) {
         ConfigHandler().setSavePath(path);
         saveMessage = QObject::tr("Capture saved as ") + completePath;
     } else {
         saveMessage = QObject::tr("Error trying to save as ") + completePath;
+        notificationPath = "";
     }
 
-    SystemNotification().sendMessage(saveMessage, ok ? completePath : "");
+    SystemNotification().sendMessage(saveMessage, notificationPath);
     return ok;
 }
 

--- a/src/utils/systemnotification.h
+++ b/src/utils/systemnotification.h
@@ -26,10 +26,12 @@ class SystemNotification : public QObject {
 public:
     explicit SystemNotification(QObject *parent = nullptr);
 
-    void sendMessage(const QString &text);
+    void sendMessage(const QString &text,
+                     const QString &savePath = {});
 
     void sendMessage(const QString &text,
                      const QString &title,
+                     const QString &savePath,
                      const int timeout = 5000);
 
 private:


### PR DESCRIPTION
The x-kde-urls field in the hints map allows us to provide a direct URL to the saved screenshot. This will allow KDE to show a thumbnail and will also enable drag and drop functionality.


![img](https://i.imgur.com/tDnMMzj.png)