### PR TITLE
Fixup working with startupLaunch value

### DIFF
--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -242,6 +242,21 @@ void ConfigHandler::setKeepOpenAppLauncher(const bool keepOpen) {
 
 bool ConfigHandler::startupLaunchValue() {
     bool res = false;
+
+    if (m_settings.contains(QStringLiteral("startupLaunch"))) {
+        res = m_settings.value(QStringLiteral("startupLaunch")).toBool();
+    }
+
+    if (res != verifyLaunchFile()) {
+        setStartupLaunch(res);
+    }
+
+    return res;
+}
+
+bool ConfigHandler::verifyLaunchFile() {
+    bool res = false;
+
 #if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
     QString path = QDir::homePath() + "/.config/autostart/Flameshot.desktop";
     res = QFile(path).exists();
@@ -281,6 +296,7 @@ void ConfigHandler::setStartupLaunch(const bool start) {
         bootUpSettings.remove("Flameshot");
     }
 #endif
+    m_settings.setValue(QStringLiteral("startupLaunch"), start);
 }
 
 int ConfigHandler::contrastOpacityValue() {

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -272,8 +272,13 @@ bool ConfigHandler::verifyLaunchFile() {
 
 void ConfigHandler::setStartupLaunch(const bool start) {
 #if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
-    QString path = QDir::homePath() + "/.config/autostart/Flameshot.desktop";
-    QFile file(path);
+    QString path = QDir::homePath() + "/.config/autostart/";
+    QDir autostartDir(path);
+    if (!autostartDir.exists()) {
+        autostartDir.mkpath(".");
+    }
+
+    QFile file(path + "Flameshot.desktop");
     if (start) {
         if (file.open(QIODevice::WriteOnly)) {
             QByteArray data("[Desktop Entry]\nName=flameshot\nIcon=flameshot"

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -61,6 +61,7 @@ public:
     bool keepOpenAppLauncherValue();
     void setKeepOpenAppLauncher(const bool);
 
+    bool verifyLaunchFile();
     bool startupLaunchValue();
     void setStartupLaunch(const bool);
 


### PR DESCRIPTION
This commit fixes problem, when you want to import or export
information about startup.

So now program can write this value to settings, and then, when it will read it, it first of all analyses if settings value corresponds to file existence, and corrects the situation according to settings' value.