### PR TITLE
debian: Updates to debian/ packaging dir

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-flameshot (0.6~dev-1) unstable; urgency=medium
+flameshot (0.6.0-1) unstable; urgency=medium
 
   * Initial deb package.
 
- -- Boyuan Yang <073plan@gmail.com>  Mon, 07 May 2018 17:34:56 +0800
+ -- Boyuan Yang <byang@debian.org>  Wed, 27 Feb 2019 13:19:39 -0500

--- a/debian/control
+++ b/debian/control
@@ -3,14 +3,14 @@ Section: graphics
 Priority: optional
 Maintainer: Juanma Navarro Mañez <juanma1980@gmail.com>
 Uploaders:
- Boyuan Yang <073plan@gmail.com>,
+ Boyuan Yang <byang@debian.org>,
 Build-Depends:
  debhelper (>= 9),
  qt5-qmake,
  qtbase5-dev,
  qttools5-dev-tools,
- libqt5svg5-dev
-Standards-Version: 4.1.4
+ libqt5svg5-dev,
+Standards-Version: 4.3.0
 Homepage: https://github.com/lupoDharkael/flameshot
 Vcs-Browser: https://github.com/lupoDharkael/flameshot
 Vcs-Git: https://github.com/lupoDharkael/flameshot.git
@@ -18,6 +18,7 @@ Vcs-Git: https://github.com/lupoDharkael/flameshot.git
 Package: flameshot
 Architecture: any
 Depends:
+ libqt5svg5,
  ${shlibs:Depends},
  ${misc:Depends},
 Suggests:

--- a/debian/copyright
+++ b/debian/copyright
@@ -3,7 +3,7 @@ Upstream-Name: flameshot
 Source: https://github.com/lupoDharkael/flameshot/
 
 Files: *
-Copyright: 2016-2017 lupoDharkael <izhe@hotmail.es>
+Copyright: 2016-2019 lupoDharkael <izhe@hotmail.es>
 License: GPL-3+
 Comments:
  The author copied a few lines of code from KSnapshot regiongrabber.cpp
@@ -11,12 +11,17 @@ Comments:
 
 Files: debian/*
 Copyright: 2017 Juanma Navarro Mañez <juanma1980@gmail.com>
-           2018 Boyuan Yang <073plan@gmail.com>
+           2018-2019 Boyuan Yang <byang@debian.org>
 License: GPL-3+
 
 Files: img/flameshot.*
 Copyright: 2017 lupoDharkael <izhe@hotmail.es>
 License: Free-Art-License-1.3
+
+Files:
+ docs/appdata/flameshot.appdata.xml
+Copyright: 2017-2019 lupoDharkael <izhe@hotmail.es>
+License: CC0-1.0
 
 Files: img/buttonIconsBlack/* img/buttonIconsWhite/*
 Copyright: Google Inc.
@@ -375,3 +380,7 @@ License: GPL-3+
  .
  On Debian systems, the complete text of the GNU General
  Public License version 3 can be found in "/usr/share/common-licenses/GPL-3".
+
+License: CC0-1.0
+ On Debian systems, the complete text of the Creative Commons Zero v1.0
+ Universal License can be found in "/usr/share/common-licenses/CC0-1.0".

--- a/debian/rules
+++ b/debian/rules
@@ -22,9 +22,3 @@ override_dh_auto_configure:
 	# The existence of an empty .git directory triggers syncqt.
 	mkdir .git || true
 	dh_auto_configure -- CONFIG+=packaging CONFIG-=debug CONFIG+=release
-
-# dh_make generated override targets
-# This is example for Cmake (See https://bugs.debian.org/641051 )
-#override_dh_auto_configure:
-#	dh_auto_configure -- #	-DCMAKE_LIBRARY_PATH=$(DEB_HOST_MULTIARCH)
-


### PR DESCRIPTION
This commit makes some clean-up to the `debian/` packaging directory.
Most importantly, the dependency to libqt5svg5 was added to ensure
that the icons are correctly displayed on all systems.

This would close #335 .