### PR TITLE
Highlight with composition mode set to Multiply

### DIFF
--- a/src/tools/marker/markertool.cpp
+++ b/src/tools/marker/markertool.cpp
@@ -58,12 +58,14 @@ void MarkerTool::process(QPainter &painter, const QPixmap &pixmap, bool recordUn
     if (recordUndo) {
         updateBackup(pixmap);
     }
+    painter.setCompositionMode(QPainter::CompositionMode_Multiply);
     painter.setOpacity(0.35);
     painter.setPen(QPen(m_color, m_thickness));
     painter.drawLine(m_points.first, m_points.second);
 }
 
 void MarkerTool::paintMousePreview(QPainter &painter, const CaptureContext &context) {
+    painter.setCompositionMode(QPainter::CompositionMode_Multiply);
     painter.setOpacity(0.35);
     painter.setPen(QPen(context.color, PADDING_VALUE + context.thickness));
     painter.drawLine(context.mousePos, context.mousePos);


### PR DESCRIPTION
This improves readability of marked text.

Before:
![before](https://i.imgur.com/HkziFLD.png)

After:
![after](https://i.imgur.com/qVcMYTI.png)