### PR TITLE
Fix problem with disabled tray icon

### DIFF
--- a/src/config/geneneralconf.cpp
+++ b/src/config/geneneralconf.cpp
@@ -163,7 +163,7 @@ void GeneneralConf::initShowTrayIcon() {
     m_showTray->setToolTip(tr("Show the systemtray icon"));
     m_layout->addWidget(m_showTray);
 
-    connect(m_showTray, &QCheckBox::clicked, this,
+    connect(m_showTray, &QCheckBox::stateChanged, this,
             &GeneneralConf::showTrayIconChanged);
 #endif
 }


### PR DESCRIPTION
Steps to reproduce bug:
1.) reset settings to default
2.) export configuration
3.) set disabled tray icon
4.) import default configuration (with enabled tray icon)

Result: tray icon still disabled

Expected result: enabled try icon

Problem was in the fact, that showTrayIconChanged was executed
only when user has clicked on that checkbox. Now it run even
while importing config file.