### PR TITLE
Add quick mode

### DIFF
--- a/src/config/geneneralconf.cpp
+++ b/src/config/geneneralconf.cpp
@@ -37,6 +37,7 @@ GeneneralConf::GeneneralConf(QWidget *parent) : QWidget(parent) {
     initShowTrayIcon();
     initAutostart();
     initCloseAfterCapture();
+    initQuickMode();
 
     // this has to be at the end
     initConfingButtons();
@@ -49,6 +50,7 @@ void GeneneralConf::updateComponents() {
     m_sysNotifications->setChecked(config.desktopNotificationValue());
     m_autostart->setChecked(config.startupLaunchValue());
     m_closeAfterCapture->setChecked(config.closeAfterScreenshotValue());
+    m_quickMode->setChecked(config.quickModeEnabled());
 
 #if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
     m_showTray->setChecked(!config.disabledTrayIconValue());
@@ -221,4 +223,17 @@ void GeneneralConf::initCloseAfterCapture() {
 
     connect(m_closeAfterCapture, &QCheckBox::clicked, this,
             &GeneneralConf::closeAfterCaptureChanged);
+}
+
+void GeneneralConf::initQuickMode()
+{
+    m_quickMode = new QCheckBox(tr("Quick mode"), this);
+    ConfigHandler config;
+    m_quickMode->setChecked(config.quickModeEnabled());
+    m_quickMode->setToolTip(tr("Quick mode saves the screenshot after selecting the area"));
+    m_layout->addWidget(m_quickMode);
+
+    connect(m_quickMode, &QCheckBox::clicked, [](bool checked) {
+        ConfigHandler().setQuickModeEnabled(checked);
+    });
 }

--- a/src/config/geneneralconf.h
+++ b/src/config/geneneralconf.h
@@ -48,6 +48,7 @@ private:
     QCheckBox *m_helpMessage;
     QCheckBox *m_autostart;
     QCheckBox *m_closeAfterCapture;
+    QCheckBox *m_quickMode;
     QPushButton *m_importButton;
     QPushButton *m_exportButton;
     QPushButton *m_resetButton;
@@ -58,4 +59,5 @@ private:
     void initConfingButtons();
     void initAutostart();
     void initCloseAfterCapture();
+    void initQuickMode();
 };

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -325,6 +325,14 @@ void ConfigHandler::setCloseAfterScreenshot(const bool close) {
     m_settings.setValue(QStringLiteral("closeAfterScreenshot"), close);
 }
 
+bool ConfigHandler::quickModeEnabled() const {
+    return m_settings.value(QStringLiteral("quickMode")).toBool();
+}
+
+void ConfigHandler::setQuickModeEnabled(bool value) {
+    m_settings.setValue(QStringLiteral("quickMode"), value);
+}
+
 void ConfigHandler::setDefaults() {
     m_settings.clear();
 }

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -71,6 +71,8 @@ public:
     bool closeAfterScreenshotValue();
     void setCloseAfterScreenshot(const bool);
 
+    bool quickModeEnabled() const;
+    void setQuickModeEnabled(bool);
 
     void setDefaults();
     void setAllTheButtons();

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -458,7 +458,13 @@ void CaptureWidget::mouseReleaseEvent(QMouseEvent *e) {
         }
         m_selection->setGeometry(newGeometry);
         m_context.selection = extendedRect(&newGeometry);
+
+        if (m_config.quickModeEnabled()) {
+            saveScreenshot();
+        }
+
         updateSizeIndicator();
+
         m_buttonHandler->updatePosition(newGeometry);
         m_buttonHandler->show();
     }


### PR DESCRIPTION
Pretty naive and simple implementation of 'quick mode' that allows user to save a screenshot right after selecting part of a screen. Works best with -p option but `saveAfterCopyPath` from #516 could be used as a default save path.

Requested by #526 and partially by #394. Since I was also a user of ShareX it works for me best.

Since development here seems to take quite a lot of time, I'll unfortunately continue to work on it and other features on my fork.