### PR TITLE
Optional Xclip as clipboard manager (can save after flameshot closed)

### DIFF
--- a/src/config/geneneralconf.cpp
+++ b/src/config/geneneralconf.cpp
@@ -37,6 +37,7 @@ GeneneralConf::GeneneralConf(QWidget *parent) : QWidget(parent) {
     initShowTrayIcon();
     initAutostart();
     initCloseAfterCapture();
+    initXclipManager();
 
     // this has to be at the end
     initConfingButtons();
@@ -78,6 +79,10 @@ void GeneneralConf::autostartChanged(bool checked) {
 
 void GeneneralConf::closeAfterCaptureChanged(bool checked) {
     ConfigHandler().setCloseAfterScreenshot(checked);
+}
+
+void GeneneralConf::useXclipManagerChanged(bool checked) {
+    ConfigHandler().setXclipManager(checked);
 }
 
 void GeneneralConf::importConfiguration() {
@@ -221,4 +226,15 @@ void GeneneralConf::initCloseAfterCapture() {
 
     connect(m_closeAfterCapture, &QCheckBox::clicked, this,
             &GeneneralConf::closeAfterCaptureChanged);
+}
+
+void GeneneralConf::initXclipManager() {
+    m_xclipManager = new QCheckBox(tr("Use xclip to save on clipboard"), this);
+    ConfigHandler config;
+    bool checked = config.useXclipManagerValue();
+    m_xclipManager->setChecked(checked);
+    m_xclipManager->setToolTip(tr("Use xclip to save on clipboard"));
+    m_layout->addWidget(m_xclipManager);
+    connect(m_xclipManager, &QCheckBox::clicked, this,
+            &GeneneralConf::useXclipManagerChanged);
 }

--- a/src/config/geneneralconf.h
+++ b/src/config/geneneralconf.h
@@ -37,6 +37,7 @@ private slots:
    void showTrayIconChanged(bool checked);
    void autostartChanged(bool checked);
    void closeAfterCaptureChanged(bool checked);
+   void useXclipManagerChanged(bool checked);
    void importConfiguration();
    void exportFileConfiguration();
    void resetConfiguration();
@@ -48,6 +49,7 @@ private:
     QCheckBox *m_helpMessage;
     QCheckBox *m_autostart;
     QCheckBox *m_closeAfterCapture;
+    QCheckBox *m_xclipManager;
     QPushButton *m_importButton;
     QPushButton *m_exportButton;
     QPushButton *m_resetButton;
@@ -58,4 +60,5 @@ private:
     void initConfingButtons();
     void initAutostart();
     void initCloseAfterCapture();
+    void initXclipManager();
 };

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -325,6 +325,14 @@ void ConfigHandler::setCloseAfterScreenshot(const bool close) {
     m_settings.setValue(QStringLiteral("closeAfterScreenshot"), close);
 }
 
+bool ConfigHandler::useXclipManagerValue() {
+    return m_settings.value(QStringLiteral("xclipManager")).toBool();
+}
+
+void ConfigHandler::setXclipManager(const bool xclip) {
+    return m_settings.setValue(QStringLiteral("xclipManager"), xclip);
+}
+
 void ConfigHandler::setDefaults() {
     m_settings.clear();
 }

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -71,6 +71,8 @@ public:
     bool closeAfterScreenshotValue();
     void setCloseAfterScreenshot(const bool);
 
+    bool useXclipManagerValue();
+    void setXclipManager(const bool);
 
     void setDefaults();
     void setAllTheButtons();

--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -45,14 +45,13 @@ void ScreenshotSaver::saveToClipboard(const QPixmap &capture) {
         snprintf(save, sizeof(save),"cat %s | xclip -selection clipboard -target image/png -i", tmp_file);
         system(save);
 
-        char rm[100 + sizeof(tmp_file)];
-        snprintf(rm, sizeof(rm),"rm -f %s", tmp_file);
-        system(rm);
-
         SystemNotification().sendMessage(
                 QObject::tr("Saved to global clipboard"));
     }
 
+    char rm[100 + sizeof(tmp_file)];
+    snprintf(rm, sizeof(rm),"rm -f %s", tmp_file);
+    system(rm);
 }
 
 bool ScreenshotSaver::saveToFilesystem(const QPixmap &capture,

--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -33,22 +33,24 @@ bool useXclipClipboard(const QPixmap &capture) {
     char tmp_file[] = "/tmp/clip.XXXXXX.png";
     mkstemps(tmp_file, 4);
     bool success = capture.save(QString(tmp_file), 0, -1);
-    if (!success) return false;
 
-    // save tmp file to clipboard using xclip
-    char save[100 + sizeof(tmp_file)];
-    snprintf(save, sizeof(save),"cat %s | xclip -selection clipboard -target image/png -i", tmp_file);
-    system(save);
+    if (success) {
+        // save tmp file to clipboard using xclip
+        char save[100 + sizeof(tmp_file)];
+        snprintf(save, sizeof(save),"cat %s | xclip -selection clipboard -target image/png -i", tmp_file);
+        system(save);
 
-    SystemNotification().sendMessage(
-            QObject::tr("Saved to global clipboard"));
-    
+        SystemNotification().sendMessage(
+                QObject::tr("Saved to global clipboard"));
+        
+    }
+
     // remove tmp file
     char rm[100 + sizeof(tmp_file)];
     snprintf(rm, sizeof(rm),"rm -f %s", tmp_file);
     system(rm);
 
-    return true;
+    return success;
 }
 
 void ScreenshotSaver::saveToClipboard(const QPixmap &capture) {


### PR DESCRIPTION
Having flameshot open when rarely screenshots are made, can be annoying. Therefore, with an optional dependency (xclip), that almost everyone has.., now you can save the screenshot to the clipboard even after flameshot instance closes. 
This is a further improvement on issue #257 .
Simply, by checking a checkbox this option is activated.

This is done by saving the image to a temporary file and then saving that file to clipboard. In case saving to that file was not successful, the regular Qt clipboard manager is used.

Possibly another way to do this:
Output the screenshotted image to terminal, so people can apply their own scripts on the image

