### PR TITLE
Add qt5-qtsvg to the dependencies

### DIFF
--- a/rpm/flameshot.spec
+++ b/rpm/flameshot.spec
@@ -25,6 +25,7 @@ BuildRequires: git
 
 Requires: qt5-qtbase >= 5.3.0
 Requires: qt5-qttools
+Requires: qt5-qtsvg
 
 %description
 Flameshot is a screenshot software, it's


### PR DESCRIPTION
Without qt5-qtsvg tool icons aren't rendered see #335 - I had to manually install this package on xfce to have tool icons show up