### PR TITLE
Fix incorrect selection rectangle geometry bug

### DIFF
--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -393,7 +393,11 @@ void CaptureWidget::mouseMoveEvent(QMouseEvent *e) {
                     r.setLeft(r.left() - offset.x());
                 }
             }
-            m_selection->setGeometry(r.intersected(rect()).normalized());
+            QRect const intersectionResult = r.intersected(rect()).normalized();
+            if(intersectionResult.isNull())
+                m_selection->setGeometry(r);
+            else
+                m_selection->setGeometry(intersectionResult);
             update();
         }
     } else if (m_mouseIsClicked && m_activeTool) {
@@ -444,7 +448,13 @@ void CaptureWidget::mouseReleaseEvent(QMouseEvent *e) {
     // of a new one.
     if (!m_buttonHandler->isVisible() && m_selection->isVisible()) {
         // Don't go outside
-        QRect newGeometry = m_selection->geometry().intersected(rect());
+        QRect const intersectionResult = m_selection->geometry().intersected(rect());
+        QRect newGeometry;
+        if(intersectionResult.isNull()) {
+            newGeometry = m_selection->geometry();
+        } else {
+            newGeometry = intersectionResult;
+        }
         // normalize
         if (newGeometry.width() <= 0) {
             int left = newGeometry.left();


### PR DESCRIPTION
This commit fixes bug where selection rectangle coordinates and geometry
is set to 0 if is is positioned at the edge of the screen and then resized
to have its width or height to 0

![bug](https://user-images.githubusercontent.com/3630199/79824521-a612de00-8353-11ea-8134-e4bd2601954c.gif)
