### PR TITLE
Create a Hot Key to run Flameshot.

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ openssl, ca-certificates
 - The main code is licensed under [GPLv3](./LICENSE)
 - The logo of Flameshot is licensed under [Free Art License v1.3](./img/flameshotLogoLicense.txt)
 - The button icons are licensed under Apache License 2.0. See: https://github.com/google/material-design-icons
+- QHotkey (BSD3)
 - The code at capture/capturewidget.cpp is based on https://github.com/ckaiser/Lightscreen/blob/master/dialogs/areadialog.cpp (GPLv2)
 - The code at capture/capturewidget.h is based on https://github.com/ckaiser/Lightscreen/blob/master/dialogs/areadialog.h (GPLv2)
 - I copied a few lines of code from KSnapshot regiongrabber.cpp revision 796531 (LGPL)

--- a/flameshot.pro
+++ b/flameshot.pro
@@ -65,6 +65,9 @@ DEFINES += QT_DEPRECATED_WARNINGS
 
 include(src/third-party/singleapplication/singleapplication.pri)
 include(src/third-party/Qt-Color-Widgets//color_widgets.pri)
+win32 {
+    include(src/third-party/QHotkey/qhotkey.pri)
+}
 
 DEFINES += QAPPLICATION_CLASS=QApplication
 

--- a/src/third-party/QHotkey/LICENSE
+++ b/src/third-party/QHotkey/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2016, Felix Barz
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of QHotkey nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/third-party/QHotkey/QHotkey.pro
+++ b/src/third-party/QHotkey/QHotkey.pro
@@ -1,0 +1,10 @@
+TEMPLATE = subdirs
+
+SUBDIRS += \
+	HotkeyTest \
+    QHotkey
+
+DISTFILES += README.md \
+	LICENSE \
+	doc/qhotkey.doxy \
+	doc/qhotkey.dox

--- a/src/third-party/QHotkey/QHotkey/QHotkey
+++ b/src/third-party/QHotkey/QHotkey/QHotkey
@@ -1,0 +1,1 @@
+#include "qhotkey.h"

--- a/src/third-party/QHotkey/QHotkey/QHotkey.pro
+++ b/src/third-party/QHotkey/QHotkey/QHotkey.pro
@@ -1,0 +1,16 @@
+TEMPLATE = lib
+win32: CONFIG += dll
+
+TARGET = QHotkey
+VERSION = 1.2.1
+
+include(../qhotkey.pri)
+
+DEFINES += QHOTKEY_LIB QHOTKEY_LIB_BUILD
+
+# use INSTALL_ROOT to modify the install location
+headers.files = $$PUBLIC_HEADERS
+headers.path = $$[QT_INSTALL_HEADERS]
+target.path = $$[QT_INSTALL_LIBS]
+INSTALLS += target headers
+

--- a/src/third-party/QHotkey/QHotkey/qhotkey.cpp
+++ b/src/third-party/QHotkey/QHotkey/qhotkey.cpp
@@ -1,0 +1,348 @@
+#include "qhotkey.h"
+#include "qhotkey_p.h"
+#include <QCoreApplication>
+#include <QAbstractEventDispatcher>
+#include <QMetaMethod>
+#include <QThread>
+#include <QDebug>
+
+Q_LOGGING_CATEGORY(logQHotkey, "QHotkey")
+
+void QHotkey::addGlobalMapping(const QKeySequence &shortcut, const QHotkey::NativeShortcut &nativeShortcut)
+{
+	QMetaObject::invokeMethod(QHotkeyPrivate::instance(), "addMappingInvoked", Qt::QueuedConnection,
+							  Q_ARG(Qt::Key, Qt::Key(shortcut[0] & ~Qt::KeyboardModifierMask)),
+							  Q_ARG(Qt::KeyboardModifiers, Qt::KeyboardModifiers(shortcut[0] & Qt::KeyboardModifierMask)),
+							  Q_ARG(QHotkey::NativeShortcut, nativeShortcut));
+}
+
+QHotkey::QHotkey(QObject *parent) :
+	QObject(parent),
+	_keyCode(Qt::Key_unknown),
+	_modifiers(Qt::NoModifier),
+	_nativeShortcut(),
+	_registered(false)
+{}
+
+QHotkey::QHotkey(const QKeySequence &sequence, bool autoRegister, QObject *parent) :
+	QHotkey(parent)
+{
+	setShortcut(sequence, autoRegister);
+}
+
+QHotkey::QHotkey(Qt::Key keyCode, Qt::KeyboardModifiers modifiers, bool autoRegister, QObject *parent) :
+	QHotkey(parent)
+{
+	setShortcut(keyCode, modifiers, autoRegister);
+}
+
+QHotkey::QHotkey(const QHotkey::NativeShortcut &shortcut, bool autoRegister, QObject *parent) :
+	QHotkey(parent)
+{
+	setNativeShortcut(shortcut, autoRegister);
+}
+
+QHotkey::~QHotkey()
+{
+	if(_registered)
+		QHotkeyPrivate::instance()->removeShortcut(this);
+}
+
+QKeySequence QHotkey::shortcut() const
+{
+	if(_keyCode == Qt::Key_unknown)
+		return QKeySequence();
+	else
+		return QKeySequence(_keyCode | _modifiers);
+}
+
+Qt::Key QHotkey::keyCode() const
+{
+	return _keyCode;
+}
+
+Qt::KeyboardModifiers QHotkey::modifiers() const
+{
+	return _modifiers;
+}
+
+QHotkey::NativeShortcut QHotkey::currentNativeShortcut() const
+{
+	return _nativeShortcut;
+}
+
+bool QHotkey::isRegistered() const
+{
+	return _registered;
+}
+
+bool QHotkey::setShortcut(const QKeySequence &shortcut, bool autoRegister)
+{
+	if(shortcut.isEmpty()) {
+		return resetShortcut();
+	} else if(shortcut.count() > 1) {
+		qCWarning(logQHotkey, "Keysequences with multiple shortcuts are not allowed! "
+							  "Only the first shortcut will be used!");
+	}
+
+	return setShortcut(Qt::Key(shortcut[0] & ~Qt::KeyboardModifierMask),
+			Qt::KeyboardModifiers(shortcut[0] & Qt::KeyboardModifierMask),
+			autoRegister);
+}
+
+bool QHotkey::setShortcut(Qt::Key keyCode, Qt::KeyboardModifiers modifiers, bool autoRegister)
+{
+	if(_registered) {
+		if(autoRegister) {
+			if(!QHotkeyPrivate::instance()->removeShortcut(this))
+				return false;
+		} else
+			return false;
+	}
+
+	if(keyCode == Qt::Key_unknown) {
+		_keyCode = Qt::Key_unknown;
+		_modifiers = Qt::NoModifier;
+		_nativeShortcut = NativeShortcut();
+		return true;
+	}
+
+	_keyCode = keyCode;
+	_modifiers = modifiers;
+	_nativeShortcut = QHotkeyPrivate::instance()->nativeShortcut(keyCode, modifiers);
+	if(_nativeShortcut.isValid()) {
+		if(autoRegister)
+			return QHotkeyPrivate::instance()->addShortcut(this);
+		else
+			return true;
+	} else {
+		qCWarning(logQHotkey) << "Unable to map shortcut to native keys. Key:" << keyCode << "Modifiers:" << modifiers;
+		_keyCode = Qt::Key_unknown;
+		_modifiers = Qt::NoModifier;
+		_nativeShortcut = NativeShortcut();
+		return false;
+	}
+}
+
+bool QHotkey::resetShortcut()
+{
+	if(_registered &&
+	   !QHotkeyPrivate::instance()->removeShortcut(this)) {
+		return false;
+	}
+
+	_keyCode = Qt::Key_unknown;
+	_modifiers = Qt::NoModifier;
+	_nativeShortcut = NativeShortcut();
+	return true;
+}
+
+bool QHotkey::setNativeShortcut(QHotkey::NativeShortcut nativeShortcut, bool autoRegister)
+{
+	if(_registered) {
+		if(autoRegister) {
+			if(!QHotkeyPrivate::instance()->removeShortcut(this))
+				return false;
+		} else
+			return false;
+	}
+
+	if(nativeShortcut.isValid()) {
+		_keyCode = Qt::Key_unknown;
+		_modifiers = Qt::NoModifier;
+		_nativeShortcut = nativeShortcut;
+		if(autoRegister)
+			return QHotkeyPrivate::instance()->addShortcut(this);
+		else
+			return true;
+	} else {
+		_keyCode = Qt::Key_unknown;
+		_modifiers = Qt::NoModifier;
+		_nativeShortcut = NativeShortcut();
+		return true;
+	}
+}
+
+bool QHotkey::setRegistered(bool registered)
+{
+	if(_registered && !registered)
+		return QHotkeyPrivate::instance()->removeShortcut(this);
+	else if(!_registered && registered) {
+		if(!_nativeShortcut.isValid())
+			return false;
+		else
+			return QHotkeyPrivate::instance()->addShortcut(this);
+	} else
+		return true;
+}
+
+
+
+// ---------- QHotkeyPrivate implementation ----------
+
+QHotkeyPrivate::QHotkeyPrivate() :
+	shortcuts()
+{
+	Q_ASSERT_X(qApp, Q_FUNC_INFO, "QHotkey requires QCoreApplication to be instantiated");
+	qApp->eventDispatcher()->installNativeEventFilter(this);
+}
+
+QHotkeyPrivate::~QHotkeyPrivate()
+{
+	if(!shortcuts.isEmpty())
+		qCWarning(logQHotkey) << "QHotkeyPrivate destroyed with registered shortcuts!";
+	if(qApp && qApp->eventDispatcher())
+		qApp->eventDispatcher()->removeNativeEventFilter(this);
+}
+
+QHotkey::NativeShortcut QHotkeyPrivate::nativeShortcut(Qt::Key keycode, Qt::KeyboardModifiers modifiers)
+{
+	Qt::ConnectionType conType = (QThread::currentThread() == thread() ?
+									  Qt::DirectConnection :
+									  Qt::BlockingQueuedConnection);
+	QHotkey::NativeShortcut res;
+	if(!QMetaObject::invokeMethod(this, "nativeShortcutInvoked", conType,
+								  Q_RETURN_ARG(QHotkey::NativeShortcut, res),
+								  Q_ARG(Qt::Key, keycode),
+								  Q_ARG(Qt::KeyboardModifiers, modifiers))) {
+		return QHotkey::NativeShortcut();
+	} else
+		return res;
+}
+
+bool QHotkeyPrivate::addShortcut(QHotkey *hotkey)
+{
+	if(hotkey->_registered)
+		return false;
+
+	Qt::ConnectionType conType = (QThread::currentThread() == thread() ?
+									  Qt::DirectConnection :
+									  Qt::BlockingQueuedConnection);
+	bool res = false;
+	if(!QMetaObject::invokeMethod(this, "addShortcutInvoked", conType,
+								  Q_RETURN_ARG(bool, res),
+								  Q_ARG(QHotkey*, hotkey))) {
+		return false;
+	} else {
+		if(res)
+			emit hotkey->registeredChanged(true);
+		return res;
+	}
+}
+
+bool QHotkeyPrivate::removeShortcut(QHotkey *hotkey)
+{
+	if(!hotkey->_registered)
+		return false;
+
+	Qt::ConnectionType conType = (QThread::currentThread() == thread() ?
+									  Qt::DirectConnection :
+									  Qt::BlockingQueuedConnection);
+	bool res = false;
+	if(!QMetaObject::invokeMethod(this, "removeShortcutInvoked", conType,
+								  Q_RETURN_ARG(bool, res),
+								  Q_ARG(QHotkey*, hotkey))) {
+		return false;
+	} else {
+		if(res)
+			emit hotkey->registeredChanged(false);
+		return res;
+	}
+}
+
+void QHotkeyPrivate::activateShortcut(QHotkey::NativeShortcut shortcut)
+{
+	QMetaMethod signal = QMetaMethod::fromSignal(&QHotkey::activated);
+	for(QHotkey *hkey : shortcuts.values(shortcut))
+		signal.invoke(hkey, Qt::QueuedConnection);
+}
+
+void QHotkeyPrivate::addMappingInvoked(Qt::Key keycode, Qt::KeyboardModifiers modifiers, const QHotkey::NativeShortcut &nativeShortcut)
+{
+	mapping.insert({keycode, modifiers}, nativeShortcut);
+}
+
+bool QHotkeyPrivate::addShortcutInvoked(QHotkey *hotkey)
+{
+	QHotkey::NativeShortcut shortcut = hotkey->_nativeShortcut;
+
+	if(!shortcuts.contains(shortcut)) {
+		if(!registerShortcut(shortcut))
+			return false;
+	}
+
+	shortcuts.insert(shortcut, hotkey);
+	hotkey->_registered = true;
+	return true;
+}
+
+bool QHotkeyPrivate::removeShortcutInvoked(QHotkey *hotkey)
+{
+	QHotkey::NativeShortcut shortcut = hotkey->_nativeShortcut;
+
+	if(shortcuts.remove(shortcut, hotkey) == 0)
+		return false;
+	hotkey->_registered = false;
+	emit hotkey->registeredChanged(true);
+	if(shortcuts.count(shortcut) == 0)
+		return unregisterShortcut(shortcut);
+	else
+		return true;
+}
+
+QHotkey::NativeShortcut QHotkeyPrivate::nativeShortcutInvoked(Qt::Key keycode, Qt::KeyboardModifiers modifiers)
+{
+	if(mapping.contains({keycode, modifiers}))
+		return mapping.value({keycode, modifiers});
+
+	bool ok1, ok2 = false;
+	auto k = nativeKeycode(keycode, ok1);
+	auto m = nativeModifiers(modifiers, ok2);
+	if(ok1 && ok2)
+		return {k, m};
+	else
+		return {};
+}
+
+
+
+QHotkey::NativeShortcut::NativeShortcut() :
+	key(),
+	modifier(),
+	valid(false)
+{}
+
+QHotkey::NativeShortcut::NativeShortcut(quint32 key, quint32 modifier) :
+	key(key),
+	modifier(modifier),
+	valid(true)
+{}
+
+bool QHotkey::NativeShortcut::isValid() const
+{
+	return valid;
+}
+
+bool QHotkey::NativeShortcut::operator ==(const QHotkey::NativeShortcut &other) const
+{
+	return (key == other.key) &&
+		   (modifier == other.modifier) &&
+		   valid == other.valid;
+}
+
+bool QHotkey::NativeShortcut::operator !=(const QHotkey::NativeShortcut &other) const
+{
+	return (key != other.key) ||
+		   (modifier != other.modifier) ||
+		   valid != other.valid;
+}
+
+uint qHash(const QHotkey::NativeShortcut &key)
+{
+	return qHash(key.key) ^ qHash(key.modifier);
+}
+
+uint qHash(const QHotkey::NativeShortcut &key, uint seed)
+{
+	return qHash(key.key, seed) ^ qHash(key.modifier, seed);
+}

--- a/src/third-party/QHotkey/QHotkey/qhotkey.h
+++ b/src/third-party/QHotkey/QHotkey/qhotkey.h
@@ -1,0 +1,118 @@
+#ifndef QHOTKEY_H
+#define QHOTKEY_H
+
+#include <QObject>
+#include <QKeySequence>
+#include <QPair>
+#include <QLoggingCategory>
+
+#ifdef QHOTKEY_LIB
+	#ifdef QHOTKEY_LIB_BUILD
+		#define QHOTKEY_SHARED_EXPORT Q_DECL_EXPORT
+	#else
+		#define QHOTKEY_SHARED_EXPORT Q_DECL_IMPORT
+	#endif
+#else
+	#define QHOTKEY_SHARED_EXPORT
+#endif
+
+//! A class to define global, systemwide Hotkeys
+class QHOTKEY_SHARED_EXPORT QHotkey : public QObject
+{
+	Q_OBJECT
+	//! @private
+	friend class QHotkeyPrivate;
+
+	//! Specifies whether this hotkey is currently registered or not
+	Q_PROPERTY(bool registered READ isRegistered WRITE setRegistered NOTIFY registeredChanged)
+	//! Holds the shortcut this hotkey will be triggered on
+	Q_PROPERTY(QKeySequence shortcut READ shortcut WRITE setShortcut RESET resetShortcut)
+
+public:
+	//! Defines shortcut with native keycodes
+	class QHOTKEY_SHARED_EXPORT NativeShortcut {
+	public:
+		//! The native keycode
+		quint32 key;
+		//! The native modifiers
+		quint32 modifier;
+
+		//! Creates an invalid native shortcut
+		NativeShortcut();
+		//! Creates a valid native shortcut, with the given key and modifiers
+		NativeShortcut(quint32 key, quint32 modifier = 0);
+
+		//! Checks, whether this shortcut is valid or not
+		bool isValid() const;
+
+		//! Equality operator
+		bool operator ==(const NativeShortcut &other) const;
+		//! Inequality operator
+		bool operator !=(const NativeShortcut &other) const;
+
+	private:
+		bool valid;
+	};
+
+	//! Adds a global mapping of a key sequence to a replacement native shortcut
+	static void addGlobalMapping(const QKeySequence &shortcut, const NativeShortcut &nativeShortcut);
+
+	//! Default Constructor
+	explicit QHotkey(QObject *parent = nullptr);
+	//! Constructs a hotkey with a shortcut and optionally registers it
+	explicit QHotkey(const QKeySequence &shortcut, bool autoRegister = false, QObject *parent = nullptr);
+	//! Constructs a hotkey with a key and modifiers and optionally registers it
+	explicit QHotkey(Qt::Key keyCode, Qt::KeyboardModifiers modifiers, bool autoRegister = false, QObject *parent = nullptr);
+	//! Constructs a hotkey from a native shortcut and optionally registers it
+	explicit QHotkey(const NativeShortcut &shortcut, bool autoRegister = false, QObject *parent = nullptr);
+	~QHotkey();
+
+	//! @readAcFn{QHotkey::registered}
+	bool isRegistered() const;
+	//! @readAcFn{QHotkey::shortcut}
+	QKeySequence shortcut() const;
+	//! @readAcFn{QHotkey::shortcut} - the key only
+	Qt::Key keyCode() const;
+	//! @readAcFn{QHotkey::shortcut} - the modifiers only
+	Qt::KeyboardModifiers modifiers() const;
+
+	//! Get the current native shortcut
+	NativeShortcut currentNativeShortcut() const;
+
+public slots:
+	//! @writeAcFn{QHotkey::registered}
+	bool setRegistered(bool registered);
+
+	//! @writeAcFn{QHotkey::shortcut}
+	bool setShortcut(const QKeySequence &shortcut, bool autoRegister = false);
+	//! @writeAcFn{QHotkey::shortcut}
+	bool setShortcut(Qt::Key keyCode, Qt::KeyboardModifiers modifiers, bool autoRegister = false);
+	//! @resetAcFn{QHotkey::shortcut}
+	bool resetShortcut();
+
+	//! Set this hotkey to a native shortcut
+	bool setNativeShortcut(NativeShortcut nativeShortcut, bool autoRegister = false);
+
+signals:
+	//! Will be emitted if the shortcut is pressed
+	void activated(QPrivateSignal);
+
+	//! @notifyAcFn{QHotkey::registered}
+	void registeredChanged(bool registered);
+
+private:
+	Qt::Key _keyCode;
+	Qt::KeyboardModifiers _modifiers;
+
+	NativeShortcut _nativeShortcut;
+	bool _registered;
+};
+
+uint QHOTKEY_SHARED_EXPORT qHash(const QHotkey::NativeShortcut &key);
+uint QHOTKEY_SHARED_EXPORT qHash(const QHotkey::NativeShortcut &key, uint seed);
+
+QHOTKEY_SHARED_EXPORT Q_DECLARE_LOGGING_CATEGORY(logQHotkey)
+
+Q_DECLARE_METATYPE(QHotkey::NativeShortcut)
+
+#endif // QHOTKEY_H

--- a/src/third-party/QHotkey/QHotkey/qhotkey.pri
+++ b/src/third-party/QHotkey/QHotkey/qhotkey.pri
@@ -1,0 +1,1 @@
+message(The pri file has been moved one directory up! use that one instead)

--- a/src/third-party/QHotkey/QHotkey/qhotkey_mac.cpp
+++ b/src/third-party/QHotkey/QHotkey/qhotkey_mac.cpp
@@ -1,0 +1,261 @@
+#include "qhotkey.h"
+#include "qhotkey_p.h"
+#include <Carbon/Carbon.h>
+#include <QDebug>
+
+class QHotkeyPrivateMac : public QHotkeyPrivate
+{
+public:
+	// QAbstractNativeEventFilter interface
+	bool nativeEventFilter(const QByteArray &eventType, void *message, long *result) Q_DECL_OVERRIDE;
+
+	static OSStatus hotkeyEventHandler(EventHandlerCallRef nextHandler, EventRef event, void* data);
+
+protected:
+	// QHotkeyPrivate interface
+	quint32 nativeKeycode(Qt::Key keycode, bool &ok) Q_DECL_OVERRIDE;
+	quint32 nativeModifiers(Qt::KeyboardModifiers modifiers, bool &ok) Q_DECL_OVERRIDE;
+	bool registerShortcut(QHotkey::NativeShortcut shortcut) Q_DECL_OVERRIDE;
+	bool unregisterShortcut(QHotkey::NativeShortcut shortcut) Q_DECL_OVERRIDE;
+
+private:
+	static bool isHotkeyHandlerRegistered;
+	static QHash<QHotkey::NativeShortcut, EventHotKeyRef> hotkeyRefs;
+};
+NATIVE_INSTANCE(QHotkeyPrivateMac)
+
+bool QHotkeyPrivateMac::isHotkeyHandlerRegistered = false;
+QHash<QHotkey::NativeShortcut, EventHotKeyRef> QHotkeyPrivateMac::hotkeyRefs;
+
+bool QHotkeyPrivateMac::nativeEventFilter(const QByteArray &eventType, void *message, long *result)
+{
+	Q_UNUSED(eventType);
+	Q_UNUSED(message);
+	Q_UNUSED(result);
+	return false;
+}
+
+quint32 QHotkeyPrivateMac::nativeKeycode(Qt::Key keycode, bool &ok)
+{
+	// Constants found in NSEvent.h from AppKit.framework
+	ok = true;
+	switch (keycode) {
+	case Qt::Key_Return:
+		return kVK_Return;
+	case Qt::Key_Enter:
+		return kVK_ANSI_KeypadEnter;
+	case Qt::Key_Tab:
+		return kVK_Tab;
+	case Qt::Key_Space:
+		return kVK_Space;
+	case Qt::Key_Backspace:
+		return kVK_Delete;
+	case Qt::Key_Escape:
+		return kVK_Escape;
+	case Qt::Key_CapsLock:
+		return kVK_CapsLock;
+	case Qt::Key_Option:
+		return kVK_Option;
+	case Qt::Key_F17:
+		return kVK_F17;
+	case Qt::Key_VolumeUp:
+		return kVK_VolumeUp;
+	case Qt::Key_VolumeDown:
+		return kVK_VolumeDown;
+	case Qt::Key_F18:
+		return kVK_F18;
+	case Qt::Key_F19:
+		return kVK_F19;
+	case Qt::Key_F20:
+		return kVK_F20;
+	case Qt::Key_F5:
+		return kVK_F5;
+	case Qt::Key_F6:
+		return kVK_F6;
+	case Qt::Key_F7:
+		return kVK_F7;
+	case Qt::Key_F3:
+		return kVK_F3;
+	case Qt::Key_F8:
+		return kVK_F8;
+	case Qt::Key_F9:
+		return kVK_F9;
+	case Qt::Key_F11:
+		return kVK_F11;
+	case Qt::Key_F13:
+		return kVK_F13;
+	case Qt::Key_F16:
+		return kVK_F16;
+	case Qt::Key_F14:
+		return kVK_F14;
+	case Qt::Key_F10:
+		return kVK_F10;
+	case Qt::Key_F12:
+		return kVK_F12;
+	case Qt::Key_F15:
+		return kVK_F15;
+	case Qt::Key_Help:
+		return kVK_Help;
+	case Qt::Key_Home:
+		return kVK_Home;
+	case Qt::Key_PageUp:
+		return kVK_PageUp;
+	case Qt::Key_Delete:
+		return kVK_ForwardDelete;
+	case Qt::Key_F4:
+		return kVK_F4;
+	case Qt::Key_End:
+		return kVK_End;
+	case Qt::Key_F2:
+		return kVK_F2;
+	case Qt::Key_PageDown:
+		return kVK_PageDown;
+	case Qt::Key_F1:
+		return kVK_F1;
+	case Qt::Key_Left:
+		return kVK_LeftArrow;
+	case Qt::Key_Right:
+		return kVK_RightArrow;
+	case Qt::Key_Down:
+		return kVK_DownArrow;
+	case Qt::Key_Up:
+		return kVK_UpArrow;
+	default:
+		ok = false;
+		break;
+	}
+
+	UTF16Char ch = keycode;
+
+	CFDataRef currentLayoutData;
+	TISInputSourceRef currentKeyboard = TISCopyCurrentKeyboardInputSource();
+
+	if (currentKeyboard == NULL)
+		return 0;
+
+	currentLayoutData = (CFDataRef)TISGetInputSourceProperty(currentKeyboard, kTISPropertyUnicodeKeyLayoutData);
+	CFRelease(currentKeyboard);
+	if (currentLayoutData == NULL)
+		return 0;
+
+	UCKeyboardLayout* header = (UCKeyboardLayout*)CFDataGetBytePtr(currentLayoutData);
+	UCKeyboardTypeHeader* table = header->keyboardTypeList;
+
+	uint8_t *data = (uint8_t*)header;
+	for (quint32 i=0; i < header->keyboardTypeCount; i++) {
+		UCKeyStateRecordsIndex* stateRec = 0;
+		if (table[i].keyStateRecordsIndexOffset != 0) {
+			stateRec = reinterpret_cast<UCKeyStateRecordsIndex*>(data + table[i].keyStateRecordsIndexOffset);
+			if (stateRec->keyStateRecordsIndexFormat != kUCKeyStateRecordsIndexFormat) stateRec = 0;
+		}
+
+		UCKeyToCharTableIndex* charTable = reinterpret_cast<UCKeyToCharTableIndex*>(data + table[i].keyToCharTableIndexOffset);
+		if (charTable->keyToCharTableIndexFormat != kUCKeyToCharTableIndexFormat) continue;
+
+		for (quint32 j=0; j < charTable->keyToCharTableCount; j++) {
+			UCKeyOutput* keyToChar = reinterpret_cast<UCKeyOutput*>(data + charTable->keyToCharTableOffsets[j]);
+			for (quint32 k=0; k < charTable->keyToCharTableSize; k++) {
+				if (keyToChar[k] & kUCKeyOutputTestForIndexMask) {
+					long idx = keyToChar[k] & kUCKeyOutputGetIndexMask;
+					if (stateRec && idx < stateRec->keyStateRecordCount) {
+						UCKeyStateRecord* rec = reinterpret_cast<UCKeyStateRecord*>(data + stateRec->keyStateRecordOffsets[idx]);
+						if (rec->stateZeroCharData == ch) {
+							ok = true;
+							return k;
+						}
+					}
+				}
+				else if (!(keyToChar[k] & kUCKeyOutputSequenceIndexMask) && keyToChar[k] < 0xFFFE) {
+					if (keyToChar[k] == ch) {
+						ok = true;
+						return k;
+					}
+				}
+			}
+		}
+	}
+	return 0;
+}
+
+quint32 QHotkeyPrivateMac::nativeModifiers(Qt::KeyboardModifiers modifiers, bool &ok)
+{
+	quint32 nMods = 0;
+	if (modifiers & Qt::ShiftModifier)
+		nMods |= shiftKey;
+	if (modifiers & Qt::ControlModifier)
+		nMods |= cmdKey;
+	if (modifiers & Qt::AltModifier)
+		nMods |= optionKey;
+	if (modifiers & Qt::MetaModifier)
+		nMods |= controlKey;
+	if (modifiers & Qt::KeypadModifier)
+		nMods |= kEventKeyModifierNumLockMask;
+	ok = true;
+	return nMods;
+}
+
+bool QHotkeyPrivateMac::registerShortcut(QHotkey::NativeShortcut shortcut)
+{
+	if (!this->isHotkeyHandlerRegistered)
+	{
+		EventTypeSpec eventSpec;
+		eventSpec.eventClass = kEventClassKeyboard;
+		eventSpec.eventKind = kEventHotKeyPressed;
+		InstallApplicationEventHandler(&QHotkeyPrivateMac::hotkeyEventHandler, 1, &eventSpec, NULL, NULL);
+	}
+
+	EventHotKeyID hkeyID;
+	hkeyID.signature = shortcut.key;
+	hkeyID.id = shortcut.modifier;
+
+	EventHotKeyRef eventRef = 0;
+	OSStatus status = RegisterEventHotKey(shortcut.key,
+										  shortcut.modifier,
+										  hkeyID,
+										  GetApplicationEventTarget(),
+										  0,
+										  &eventRef);
+	if (status != noErr) {
+		qCWarning(logQHotkey) << "Failed to register hotkey. Error:"
+							  << status;
+		return false;
+	} else {
+		this->hotkeyRefs.insert(shortcut, eventRef);
+		return true;
+	}
+}
+
+bool QHotkeyPrivateMac::unregisterShortcut(QHotkey::NativeShortcut shortcut)
+{
+	EventHotKeyRef eventRef = QHotkeyPrivateMac::hotkeyRefs.value(shortcut);
+	OSStatus status = UnregisterEventHotKey(eventRef);
+	if (status != noErr) {
+		qCWarning(logQHotkey) << "Failed to unregister hotkey. Error:"
+							  << status;
+		return false;
+	} else {
+		this->hotkeyRefs.remove(shortcut);
+		return true;
+	}
+}
+
+OSStatus QHotkeyPrivateMac::hotkeyEventHandler(EventHandlerCallRef nextHandler, EventRef event, void* data)
+{
+	Q_UNUSED(nextHandler);
+	Q_UNUSED(data);
+
+	if (GetEventClass(event) == kEventClassKeyboard &&
+		GetEventKind(event) == kEventHotKeyPressed) {
+		EventHotKeyID hkeyID;
+		GetEventParameter(event,
+						  kEventParamDirectObject,
+						  typeEventHotKeyID,
+						  NULL,
+						  sizeof(EventHotKeyID),
+						  NULL,
+						  &hkeyID);
+		hotkeyPrivate->activateShortcut({hkeyID.signature, hkeyID.id});
+	}
+
+	return noErr;
+}

--- a/src/third-party/QHotkey/QHotkey/qhotkey_p.h
+++ b/src/third-party/QHotkey/QHotkey/qhotkey_p.h
@@ -1,0 +1,55 @@
+#ifndef QHOTKEY_P_H
+#define QHOTKEY_P_H
+
+#include "qhotkey.h"
+#include <QAbstractNativeEventFilter>
+#include <QMultiHash>
+#include <QMutex>
+#include <QGlobalStatic>
+
+class QHOTKEY_SHARED_EXPORT QHotkeyPrivate : public QObject, public QAbstractNativeEventFilter
+{
+	Q_OBJECT
+
+public:
+	QHotkeyPrivate();//singleton!!!
+	~QHotkeyPrivate();
+
+	static QHotkeyPrivate *instance();
+
+	QHotkey::NativeShortcut nativeShortcut(Qt::Key keycode, Qt::KeyboardModifiers modifiers);
+
+	bool addShortcut(QHotkey *hotkey);
+	bool removeShortcut(QHotkey *hotkey);
+
+protected:
+	void activateShortcut(QHotkey::NativeShortcut shortcut);
+
+	virtual quint32 nativeKeycode(Qt::Key keycode, bool &ok) = 0;//platform implement
+	virtual quint32 nativeModifiers(Qt::KeyboardModifiers modifiers, bool &ok) = 0;//platform implement
+
+	virtual bool registerShortcut(QHotkey::NativeShortcut shortcut) = 0;//platform implement
+	virtual bool unregisterShortcut(QHotkey::NativeShortcut shortcut) = 0;//platform implement
+
+private:
+	QHash<QPair<Qt::Key, Qt::KeyboardModifiers>, QHotkey::NativeShortcut> mapping;
+	QMultiHash<QHotkey::NativeShortcut, QHotkey*> shortcuts;
+
+	Q_INVOKABLE void addMappingInvoked(Qt::Key keycode, Qt::KeyboardModifiers modifiers, const QHotkey::NativeShortcut &nativeShortcut);
+	Q_INVOKABLE bool addShortcutInvoked(QHotkey *hotkey);
+	Q_INVOKABLE bool removeShortcutInvoked(QHotkey *hotkey);
+	Q_INVOKABLE QHotkey::NativeShortcut nativeShortcutInvoked(Qt::Key keycode, Qt::KeyboardModifiers modifiers);
+};
+
+#define NATIVE_INSTANCE(ClassName) \
+	Q_GLOBAL_STATIC(ClassName, hotkeyPrivate) \
+	\
+	QHotkeyPrivate *QHotkeyPrivate::instance()\
+	{\
+		return hotkeyPrivate;\
+	}
+
+Q_DECLARE_METATYPE(Qt::Key)
+Q_DECLARE_METATYPE(Qt::KeyboardModifiers)
+
+#endif // QHOTKEY_P_H

--- a/src/third-party/QHotkey/QHotkey/qhotkey_win.cpp
+++ b/src/third-party/QHotkey/QHotkey/qhotkey_win.cpp
@@ -1,0 +1,272 @@
+#include "qhotkey.h"
+#include "qhotkey_p.h"
+#include <qt_windows.h>
+#include <QDebug>
+
+#define HKEY_ID(nativeShortcut) (((nativeShortcut.key ^ (nativeShortcut.modifier << 8)) & 0x0FFF) | 0x7000)
+
+class QHotkeyPrivateWin : public QHotkeyPrivate
+{
+public:
+	// QAbstractNativeEventFilter interface
+	bool nativeEventFilter(const QByteArray &eventType, void *message, long *result) Q_DECL_OVERRIDE;
+
+protected:
+	// QHotkeyPrivate interface
+	quint32 nativeKeycode(Qt::Key keycode, bool &ok) Q_DECL_OVERRIDE;
+	quint32 nativeModifiers(Qt::KeyboardModifiers modifiers, bool &ok) Q_DECL_OVERRIDE;
+	bool registerShortcut(QHotkey::NativeShortcut shortcut) Q_DECL_OVERRIDE;
+	bool unregisterShortcut(QHotkey::NativeShortcut shortcut) Q_DECL_OVERRIDE;
+
+private:
+	static QString formatWinError(DWORD winError);
+};
+NATIVE_INSTANCE(QHotkeyPrivateWin)
+
+bool QHotkeyPrivateWin::nativeEventFilter(const QByteArray &eventType, void *message, long *result)
+{
+	Q_UNUSED(eventType);
+	Q_UNUSED(result);
+
+	MSG* msg = static_cast<MSG*>(message);
+	if(msg->message == WM_HOTKEY)
+		this->activateShortcut({HIWORD(msg->lParam), LOWORD(msg->lParam)});
+
+	return false;
+}
+
+quint32 QHotkeyPrivateWin::nativeKeycode(Qt::Key keycode, bool &ok)
+{
+	ok = true;
+	if(keycode <= 0xFFFF) {//Try to obtain the key from it's "character"
+		const SHORT vKey = VkKeyScanW(keycode);
+		if(vKey > -1)
+			return LOBYTE(vKey);
+	}
+
+	//find key from switch/case --> Only finds a very small subset of keys
+	switch (keycode)
+	{
+	case Qt::Key_Escape:
+		return VK_ESCAPE;
+	case Qt::Key_Tab:
+	case Qt::Key_Backtab:
+		return VK_TAB;
+	case Qt::Key_Backspace:
+		return VK_BACK;
+	case Qt::Key_Return:
+	case Qt::Key_Enter:
+		return VK_RETURN;
+	case Qt::Key_Insert:
+		return VK_INSERT;
+	case Qt::Key_Delete:
+		return VK_DELETE;
+	case Qt::Key_Pause:
+		return VK_PAUSE;
+	case Qt::Key_Print:
+		return VK_PRINT;
+	case Qt::Key_Clear:
+		return VK_CLEAR;
+	case Qt::Key_Home:
+		return VK_HOME;
+	case Qt::Key_End:
+		return VK_END;
+	case Qt::Key_Left:
+		return VK_LEFT;
+	case Qt::Key_Up:
+		return VK_UP;
+	case Qt::Key_Right:
+		return VK_RIGHT;
+	case Qt::Key_Down:
+		return VK_DOWN;
+	case Qt::Key_PageUp:
+		return VK_PRIOR;
+	case Qt::Key_PageDown:
+		return VK_NEXT;
+	case Qt::Key_CapsLock:
+		return VK_CAPITAL;
+	case Qt::Key_NumLock:
+		return VK_NUMLOCK;
+	case Qt::Key_ScrollLock:
+		return VK_SCROLL;
+
+	case Qt::Key_F1:
+		return VK_F1;
+	case Qt::Key_F2:
+		return VK_F2;
+	case Qt::Key_F3:
+		return VK_F3;
+	case Qt::Key_F4:
+		return VK_F4;
+	case Qt::Key_F5:
+		return VK_F5;
+	case Qt::Key_F6:
+		return VK_F6;
+	case Qt::Key_F7:
+		return VK_F7;
+	case Qt::Key_F8:
+		return VK_F8;
+	case Qt::Key_F9:
+		return VK_F9;
+	case Qt::Key_F10:
+		return VK_F10;
+	case Qt::Key_F11:
+		return VK_F11;
+	case Qt::Key_F12:
+		return VK_F12;
+	case Qt::Key_F13:
+		return VK_F13;
+	case Qt::Key_F14:
+		return VK_F14;
+	case Qt::Key_F15:
+		return VK_F15;
+	case Qt::Key_F16:
+		return VK_F16;
+	case Qt::Key_F17:
+		return VK_F17;
+	case Qt::Key_F18:
+		return VK_F18;
+	case Qt::Key_F19:
+		return VK_F19;
+	case Qt::Key_F20:
+		return VK_F20;
+	case Qt::Key_F21:
+		return VK_F21;
+	case Qt::Key_F22:
+		return VK_F22;
+	case Qt::Key_F23:
+		return VK_F23;
+	case Qt::Key_F24:
+		return VK_F24;
+
+	case Qt::Key_Menu:
+		return VK_APPS;
+	case Qt::Key_Help:
+		return VK_HELP;
+	case Qt::Key_MediaNext:
+		return VK_MEDIA_NEXT_TRACK;
+	case Qt::Key_MediaPrevious:
+		return VK_MEDIA_PREV_TRACK;
+	case Qt::Key_MediaPlay:
+		return VK_MEDIA_PLAY_PAUSE;
+	case Qt::Key_MediaStop:
+		return VK_MEDIA_STOP;
+	case Qt::Key_VolumeDown:
+		return VK_VOLUME_DOWN;
+	case Qt::Key_VolumeUp:
+		return VK_VOLUME_UP;
+	case Qt::Key_VolumeMute:
+		return VK_VOLUME_MUTE;
+	case Qt::Key_Mode_switch:
+		return VK_MODECHANGE;
+	case Qt::Key_Select:
+		return VK_SELECT;
+	case Qt::Key_Printer:
+		return VK_PRINT;
+	case Qt::Key_Execute:
+		return VK_EXECUTE;
+	case Qt::Key_Sleep:
+		return VK_SLEEP;
+	case Qt::Key_Period:
+		return VK_DECIMAL;
+	case Qt::Key_Play:
+		return VK_PLAY;
+	case Qt::Key_Cancel:
+		return VK_CANCEL;
+
+	case Qt::Key_Forward:
+		return VK_BROWSER_FORWARD;
+	case Qt::Key_Refresh:
+		return VK_BROWSER_REFRESH;
+	case Qt::Key_Stop:
+		return VK_BROWSER_STOP;
+	case Qt::Key_Search:
+		return VK_BROWSER_SEARCH;
+	case Qt::Key_Favorites:
+		return VK_BROWSER_FAVORITES;
+	case Qt::Key_HomePage:
+		return VK_BROWSER_HOME;
+
+	case Qt::Key_LaunchMail:
+		return VK_LAUNCH_MAIL;
+	case Qt::Key_LaunchMedia:
+		return VK_LAUNCH_MEDIA_SELECT;
+	case Qt::Key_Launch0:
+		return VK_LAUNCH_APP1;
+	case Qt::Key_Launch1:
+		return VK_LAUNCH_APP2;
+
+	case Qt::Key_Massyo:
+		return VK_OEM_FJ_MASSHOU;
+	case Qt::Key_Touroku:
+		return VK_OEM_FJ_TOUROKU;
+
+	default:
+		if(keycode <= 0xFFFF)
+			return (byte)keycode;
+		else {
+			ok = false;
+			return 0;
+		}
+	}
+}
+
+quint32 QHotkeyPrivateWin::nativeModifiers(Qt::KeyboardModifiers modifiers, bool &ok)
+{
+	quint32 nMods = 0;
+	if (modifiers & Qt::ShiftModifier)
+		nMods |= MOD_SHIFT;
+	if (modifiers & Qt::ControlModifier)
+		nMods |= MOD_CONTROL;
+	if (modifiers & Qt::AltModifier)
+		nMods |= MOD_ALT;
+	if (modifiers & Qt::MetaModifier)
+		nMods |= MOD_WIN;
+	ok = true;
+	return nMods;
+}
+
+bool QHotkeyPrivateWin::registerShortcut(QHotkey::NativeShortcut shortcut)
+{
+	BOOL ok = RegisterHotKey(NULL,
+							 HKEY_ID(shortcut),
+							 shortcut.modifier,
+							 shortcut.key);
+	if(ok)
+		return true;
+	else {
+		qCWarning(logQHotkey) << "Failed to register hotkey. Error:"
+							  << qPrintable(QHotkeyPrivateWin::formatWinError(::GetLastError()));
+		return false;
+	}
+}
+
+bool QHotkeyPrivateWin::unregisterShortcut(QHotkey::NativeShortcut shortcut)
+{
+	BOOL ok = UnregisterHotKey(NULL, HKEY_ID(shortcut));
+	if(ok)
+		return true;
+	else {
+		qCWarning(logQHotkey) << "Failed to unregister hotkey. Error:"
+							  << qPrintable(QHotkeyPrivateWin::formatWinError(::GetLastError()));
+		return false;
+	}
+}
+
+QString QHotkeyPrivateWin::formatWinError(DWORD winError)
+{
+	wchar_t *buffer = NULL;
+	DWORD num = FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM,
+							   NULL,
+							   winError,
+							   0,
+							   (LPWSTR)&buffer,
+							   0,
+							   NULL);
+	if(buffer) {
+		QString res = QString::fromWCharArray(buffer, num);
+		LocalFree(buffer);
+		return res;
+	} else
+		return QString();
+}

--- a/src/third-party/QHotkey/QHotkey/qhotkey_x11.cpp
+++ b/src/third-party/QHotkey/QHotkey/qhotkey_x11.cpp
@@ -1,0 +1,220 @@
+#include "qhotkey.h"
+#include "qhotkey_p.h"
+#include <QDebug>
+#include <QX11Info>
+#include <QThreadStorage>
+#include <X11/Xlib.h>
+#include <xcb/xcb.h>
+
+//compability to pre Qt 5.8
+#ifndef Q_FALLTHROUGH
+#define Q_FALLTHROUGH() (void)0
+#endif
+
+class QHotkeyPrivateX11 : public QHotkeyPrivate
+{
+public:
+	// QAbstractNativeEventFilter interface
+	bool nativeEventFilter(const QByteArray &eventType, void *message, long *result) Q_DECL_OVERRIDE;
+
+protected:
+	// QHotkeyPrivate interface
+	quint32 nativeKeycode(Qt::Key keycode, bool &ok) Q_DECL_OVERRIDE;
+	quint32 nativeModifiers(Qt::KeyboardModifiers modifiers, bool &ok) Q_DECL_OVERRIDE;
+	QString getX11String(Qt::Key keycode);
+	bool registerShortcut(QHotkey::NativeShortcut shortcut) Q_DECL_OVERRIDE;
+	bool unregisterShortcut(QHotkey::NativeShortcut shortcut) Q_DECL_OVERRIDE;
+
+private:
+	static const QVector<quint32> specialModifiers;
+	static const quint32 validModsMask;
+
+	static QString formatX11Error(Display *display, int errorCode);
+
+	class HotkeyErrorHandler {
+	public:
+		HotkeyErrorHandler();
+		~HotkeyErrorHandler();
+
+		static bool hasError;
+		static QString errorString;
+
+	private:
+		XErrorHandler prevHandler;
+
+		static int handleError(Display *display, XErrorEvent *error);
+	};
+};
+NATIVE_INSTANCE(QHotkeyPrivateX11)
+
+const QVector<quint32> QHotkeyPrivateX11::specialModifiers = {0, Mod2Mask, LockMask, (Mod2Mask | LockMask)};
+const quint32 QHotkeyPrivateX11::validModsMask = ShiftMask | ControlMask | Mod1Mask | Mod4Mask;
+
+bool QHotkeyPrivateX11::nativeEventFilter(const QByteArray &eventType, void *message, long *result)
+{
+	Q_UNUSED(eventType);
+	Q_UNUSED(result);
+
+	xcb_generic_event_t *genericEvent = static_cast<xcb_generic_event_t *>(message);
+	if (genericEvent->response_type == XCB_KEY_PRESS) {
+		xcb_key_press_event_t *keyEvent = static_cast<xcb_key_press_event_t *>(message);
+		this->activateShortcut({keyEvent->detail, keyEvent->state & QHotkeyPrivateX11::validModsMask});
+	}
+
+	return false;
+}
+
+QString QHotkeyPrivateX11::getX11String(Qt::Key keycode)
+{
+	switch(keycode){
+
+		case Qt::Key_MediaLast : 
+		case Qt::Key_MediaPrevious : 
+			return "XF86AudioPrev";
+		case Qt::Key_MediaNext : 
+			return "XF86AudioNext";
+		case Qt::Key_MediaPause : 
+		case Qt::Key_MediaPlay : 
+		case Qt::Key_MediaTogglePlayPause :
+			return "XF86AudioPlay";
+		case Qt::Key_MediaRecord :
+			return "XF86AudioRecord"; 
+		case Qt::Key_MediaStop : 
+			return "XF86AudioStop";
+		default :
+			return QKeySequence(keycode).toString(QKeySequence::NativeText);
+	}
+}
+
+quint32 QHotkeyPrivateX11::nativeKeycode(Qt::Key keycode, bool &ok)
+{
+	QString keyString = getX11String(keycode);
+
+	KeySym keysym = XStringToKeysym(keyString.toLatin1().constData());
+	if (keysym == NoSymbol) {
+		//not found -> just use the key
+		if(keycode <= 0xFFFF)
+			keysym = keycode;
+		else
+			return 0;
+	}
+
+	Display *display = QX11Info::display();
+	if(display) {
+		auto res = XKeysymToKeycode(QX11Info::display(), keysym);
+		if(res != 0)
+			ok = true;
+		return res;
+	} else
+		return 0;
+}
+
+quint32 QHotkeyPrivateX11::nativeModifiers(Qt::KeyboardModifiers modifiers, bool &ok)
+{
+	quint32 nMods = 0;
+	if (modifiers & Qt::ShiftModifier)
+		nMods |= ShiftMask;
+	if (modifiers & Qt::ControlModifier)
+		nMods |= ControlMask;
+	if (modifiers & Qt::AltModifier)
+		nMods |= Mod1Mask;
+	if (modifiers & Qt::MetaModifier)
+		nMods |= Mod4Mask;
+	ok = true;
+	return nMods;
+}
+
+bool QHotkeyPrivateX11::registerShortcut(QHotkey::NativeShortcut shortcut)
+{
+	Display *display = QX11Info::display();
+	if(!display)
+		return false;
+
+	HotkeyErrorHandler errorHandler;
+	for(quint32 specialMod : QHotkeyPrivateX11::specialModifiers) {
+		XGrabKey(display,
+				 shortcut.key,
+				 shortcut.modifier | specialMod,
+				 DefaultRootWindow(display),
+				 True,
+				 GrabModeAsync,
+				 GrabModeAsync);
+	}
+	XSync(display, False);
+
+	if(errorHandler.hasError) {
+		qCWarning(logQHotkey) << "Failed to register hotkey. Error:"
+							  << qPrintable(errorHandler.errorString);
+		this->unregisterShortcut(shortcut);
+		return false;
+	} else
+		return true;
+}
+
+bool QHotkeyPrivateX11::unregisterShortcut(QHotkey::NativeShortcut shortcut)
+{
+	Display *display = QX11Info::display();
+	if(!display)
+		return false;
+
+	HotkeyErrorHandler errorHandler;
+	for(quint32 specialMod : QHotkeyPrivateX11::specialModifiers) {
+		XUngrabKey(display,
+				   shortcut.key,
+				   shortcut.modifier | specialMod,
+				   DefaultRootWindow(display));
+	}
+	XSync(display, False);
+
+	if(errorHandler.hasError) {
+		qCWarning(logQHotkey) << "Failed to unregister hotkey. Error:"
+							  << qPrintable(errorHandler.errorString);
+		return false;
+	} else
+		return true;
+}
+
+QString QHotkeyPrivateX11::formatX11Error(Display *display, int errorCode)
+{
+	char errStr[256];
+	XGetErrorText(display, errorCode, errStr, 256);
+	return QString::fromLatin1(errStr);
+}
+
+
+
+// ---------- QHotkeyPrivateX11::HotkeyErrorHandler implementation ----------
+
+bool QHotkeyPrivateX11::HotkeyErrorHandler::hasError = false;
+QString QHotkeyPrivateX11::HotkeyErrorHandler::errorString;
+
+QHotkeyPrivateX11::HotkeyErrorHandler::HotkeyErrorHandler()
+{
+	prevHandler = XSetErrorHandler(&HotkeyErrorHandler::handleError);
+}
+
+QHotkeyPrivateX11::HotkeyErrorHandler::~HotkeyErrorHandler()
+{
+	XSetErrorHandler(prevHandler);
+	hasError = false;
+	errorString.clear();
+}
+
+int QHotkeyPrivateX11::HotkeyErrorHandler::handleError(Display *display, XErrorEvent *error)
+{
+	switch (error->error_code) {
+	case BadAccess:
+	case BadValue:
+	case BadWindow:
+		if (error->request_code == 33 || //grab key
+			error->request_code == 34) {// ungrab key
+			hasError = true;
+			errorString = QHotkeyPrivateX11::formatX11Error(display, error->error_code);
+			return 1;
+		}
+		Q_FALLTHROUGH();
+		// fall through
+	default:
+		return 0;
+	}
+}

--- a/src/third-party/QHotkey/README.md
+++ b/src/third-party/QHotkey/README.md
@@ -1,0 +1,104 @@
+# QHotkey
+A global shortcut/hotkey for Desktop Qt-Applications.
+
+The QHotkey is a class that can be used to create hotkeys/global shortcuts, aka shortcuts that work everywhere, independent of the application state. This means your application can be active, inactive, minimized or not visible at all and still receive the shortcuts.
+
+## Features
+- Works on Windows, Mac and X11
+- Easy to use, can use `QKeySequence` for easy shortcut input
+- Supports almost all common keys (Depends on OS & Keyboard-Layout)
+- Allows direct input of Key/Modifier-Combinations
+- Supports multiple QHotkey-instances for the same shortcut (with optimisations)
+- Thread-Safe - Can be used on all threads (See section Thread safety)
+- Allows usage of native keycodes and modifiers, if needed
+
+**Note:** For now Wayland is not supported, as it is simply not possible to register a global shortcut with wayland. For more details, or possible Ideas on how to get Hotkeys working on wayland, see [Issue #14](https://github.com/Skycoder42/QHotkey/issues/14).
+
+## Installation
+The package is providet as qpm  package, [`de.skycoder42.qhotkey`](https://www.qpm.io/packages/de.skycoder42.qhotkey/index.html). You can install it either via qpmx (preferred) or directly via qpm.
+
+### Via qpmx
+[qpmx](https://github.com/Skycoder42/qpmx) is a frontend for qpm (and other tools) with additional features, and is the preferred way to install packages. To use it:
+
+1. Install qpmx (See [GitHub - Installation](https://github.com/Skycoder42/qpmx#installation))
+2. Install qpm (See [GitHub - Installing](https://github.com/Cutehacks/qpm/blob/master/README.md#installing), for **windows** see below)
+3. In your projects root directory, run `qpmx install de.skycoder42.qhotkey`
+
+### Via qpm
+
+1. Install qpm (See [GitHub - Installing](https://github.com/Cutehacks/qpm/blob/master/README.md#installing), for **windows** see below)
+2. In your projects root directory, run `qpm install de.skycoder42.qhotkey`
+3. Include qpm to your project by adding `include(vendor/vendor.pri)` to your `.pro` file
+
+Check their [GitHub - Usage for App Developers](https://github.com/Cutehacks/qpm/blob/master/README.md#usage-for-app-developers) to learn more about qpm.
+
+**Important for Windows users:** QPM Version *0.10.0* (the one you can download on the website) is currently broken on windows! It's already fixed in master, but not released yet. Until a newer versions gets released, you can download the latest dev build from here:
+- https://storage.googleapis.com/www.qpm.io/download/latest/windows_amd64/qpm.exe
+- https://storage.googleapis.com/www.qpm.io/download/latest/windows_386/qpm.exe
+
+## Usage
+The general usage is to create QHotkey instances for specific hotkeys, register them and then simply connect to the signal emitted once the hotkey is pressed.
+
+### Example
+The following example shows a simple application that will run without a window in the background until you press the key-combination <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>Q</kbd> (<kbd>⌘</kbd>+<kbd>⌥</kbd>+<kbd>Q</kbd> on Mac). This will quit the application. The debug output will tell if the hotkey was successfully registered and that it was pressed.
+```cpp
+#include <QHotkey>
+#include <QApplication>
+#include <QDebug>
+
+int main(int argc, char *argv[])
+{
+	QApplication a(argc, argv);
+
+	auto hotkey = new QHotkey(QKeySequence("ctrl+alt+Q"), true, &a);//The hotkey will be automatically registered
+	qDebug() << "Is Registered: " << hotkey->isRegistered();
+
+	QObject::connect(hotkey, &QHotkey::activated, qApp, [&](){
+		qDebug() << "Hotkey Activated - the application will quit now";
+		qApp->quit();
+	});
+
+	return a.exec();
+}
+```
+
+**Note:** You need the .pri include for this to work.
+
+### Testing
+By running the example in `./HotkeyTest` you can test out the QHotkey class. There are 4 sections:
+- **Playground:** You can enter some sequences here and try it out with different key combinations.
+- **Testings:** A list of selected hotkeys. Activate it and try out which ones work for you (*Hint:* Depending on OS and keyboard layout, it's very possible that a few don't work).
+- **Threading:** Activate the checkbox to move 2 Hotkeys of the playground to seperate threads. It should work without a difference.
+- **Native Shortcut**: Allows you to try out the direct usage of native shortcuts
+
+### Logging
+By default, QHotkey prints some warning messages if something goes wrong (For example, a key that cannot be translated). All messages of QHotkey are grouped into the [QLoggingCategory](https://doc.qt.io/qt-5/qloggingcategory.html) `"QHotkey"`. If you want to simply disable the logging, call the folling function somewhere in your code:
+```cpp
+QLoggingCategory::setFilterRules(QStringLiteral("QHotkey.warning=false"));
+```
+This will turn all warnings of QHotkey of (It only uses warnings for now, thats why this is enough). For more information about all the things you can do with the logging categories, check the Qt-Documentation
+
+## Thread saftey
+The QHotkey class itself is reentrant - wich means you can create as many instances as required on any thread. This allows you to use the QHotkey on all threads. **But** you should never use the QHotkey instance on a thread that is different from the one the instance belongs to! Internally the system uses a singleton instance that handles the hotkey events and distributes them to the QHotkey instances. This internal class is completley threadsafe.
+
+However, this singleton instance only runs on the main thread. (One reason is that some of the OS-Functions are not thread safe). To make threaded hotkeys possible, the critical functions (registering/unregistering hotkeys and keytranslation) are all run on the mainthread too. The QHotkey instances on other threads use `QMetaObject::invokeMethod` with a `Qt::BlockingQueuedConnection`.
+
+For you this means: QHotkey instances on other threads than the main thread may take a little longer to register/unregister/translate hotkeys, because they have to wait for the main thread to do this for them. **Important:** there is however, one additional limitation that comes with that feature: QHotkey instances on other threads but the main thread *must* be unregistered or destroyed *before* the main eventloop ends. Otherwise, your application will hangup on destruction of the hotkey. This limitation does not apply for instances on the main thread. Furthermore, the same happens if you change the shortcut or register/unregister before the loop started, until it actually starts.
+
+## Documentation
+The documentation is available as release and on [github pages](https://skycoder42.github.io/QHotkey/).
+
+The documentation was created using [doxygen](http://www.doxygen.org). It includes an HTML-documentation and Qt-Help files that can be included into QtCreator (QtAssistant) to show F1-Help (See [Adding External Documentation](https://doc.qt.io/qtcreator/creator-help.html#adding-external-documentation) for more details).
+
+## Technical
+### Requirements
+ - Explicit support is only given down to the latest Qt LTS, but may work with earlier versions, too
+ - At least the QtGui-Module (a QGuiApplication). Hotkeys on console based applications are not supported (By the operating systems). You can however create a gui application without any visible window.
+ - C++11
+
+### Known Limitations
+ - Only single key/modifier combinations are possible. If using QKeySequence, only the first key+modifier of the sequence will be used.
+ - Qt::Key makes no difference between normal numbers and the Numpad numbers. Most keyboards however require this. Thus, you can't register shortcuts for the numpad, unless you use a native shortcut.
+ - Supports not all keys, but most of the common ones. There are differences between platforms and it depends on the Keyboard-Layout. "Delete", for example, works on windows and mac, but not on X11 (At least on my test machines). I tried to use OS-Functions where possible, but since the Qt::Key values need to be converted into native keys, there are some limitations. I can use need such a key, try using the native shortcut.
+ - The registered keys will be "taken" by QHotkey. This means after a hotkey was cosumend by your application, it will not be sent to the active application. This is done this way by the operating systems and cannot be changed.
+- If you get a `QHotkey: Failed to register hotkey. Error: BadAccess (attempt to access private resource denied)` error on X11, this means you are trying to register a hotkey that is private to X11. Those keys simply cannot be registered using the normal API

--- a/src/third-party/QHotkey/qhotkey.pri
+++ b/src/third-party/QHotkey/qhotkey.pri
@@ -1,0 +1,17 @@
+CONFIG += C++11
+
+PUBLIC_HEADERS += $$PWD/QHotkey/qhotkey.h \
+	$$PWD/QHotkey/QHotkey
+
+HEADERS += $$PUBLIC_HEADERS \
+	$$PWD/QHotkey/qhotkey_p.h
+
+SOURCES += $$PWD/QHotkey/qhotkey.cpp
+
+mac: SOURCES += $$PWD/QHotkey/qhotkey_mac.cpp
+else:win32: SOURCES += $$PWD/QHotkey/qhotkey_win.cpp
+else:unix: SOURCES += $$PWD/QHotkey/qhotkey_x11.cpp
+
+INCLUDEPATH += $$PWD/QHotkey
+
+include($$PWD/qhotkey.prc)


### PR DESCRIPTION
I'm using Flameshot too well. Thank you very much. However, there is one function that is absolutely necessary. It needs a Hot Key to run Flameshot. It is inconvenient to click the Flameshot icon on the taskbar with your mouse every time. And sometimes you need screenshots right from the pop-up screen, but they disappear the moment you go to press the FlameShot icon. Please make one Hot Key setting that can be implemented.